### PR TITLE
Fix för Skandiabanken (problem med cookiehantering)

### DIFF
--- a/src/com/caucho/hessian/client/HessianHttpHeaderProxyFactory.java
+++ b/src/com/caucho/hessian/client/HessianHttpHeaderProxyFactory.java
@@ -7,7 +7,10 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.util.Map;
 
+import android.util.Log;
+
 import com.ast.util.CookieParser.Cookie;
+import com.caucho.hessian.client.HessianHttpProxyFactory.HessianHttpProxy;
 import com.caucho.hessian.io.HessianRemoteObject;
 
 // This class is added in the bankdroid project to enable adding some http-headers required by Skandiabanken
@@ -48,19 +51,16 @@ public class HessianHttpHeaderProxyFactory extends HessianHttpProxyFactory{
 			for (Map.Entry<String, String> header : mHeaderMap.entrySet())
 				conn.setRequestProperty(header.getKey(), header.getValue());
 		}
-		
+
 	    @Override
-		protected Cookie getCookie(String host, String path) {
-			Cookie cookie = super.getCookie(host, path);
-			
-			// Ugly hack: For some reason the cookie has the wrong path in the response from Skandiabanken.
-			if (cookie == null && 
-					host.contentEquals("smartrefill.se") && 
-					path.contentEquals("/")){
-				cookie = super.getCookie("smartrefill.se", "/BankServices");
-			}
-			
-			return cookie;
+		protected void putCookie(Cookie cookie) {
+	    	// Ugly hack: for some reason the path in the cookie is not as expected
+            if (cookie.host.contentEquals("smartrefill.se"))
+            {
+            	Log.d("Skandiabanken cookie", "using path / instead of " + cookie.path);
+            	cookie.path = "/";
+            }
+            super.putCookie(cookie);
 		}
 	}
 }

--- a/src/com/caucho/hessian/client/HessianHttpProxyFactory.java
+++ b/src/com/caucho/hessian/client/HessianHttpProxyFactory.java
@@ -15,6 +15,8 @@
  */
 package com.caucho.hessian.client;
 
+import android.util.Log;
+
 import com.ast.util.CookieParser;
 import com.ast.util.CookieParser.Cookie;
 import com.caucho.hessian.io.HessianRemoteObject;
@@ -120,8 +122,8 @@ public class HessianHttpProxyFactory extends HessianProxyFactory {
                 String host = conn.getURL().getHost();
                 for (String s : cookieStrings) {
                     Cookie cookie = CookieParser.parse(host, s);
-                    HessianHttpProxy.cookieMap.put(cookie.host + cookie.path, cookie);
-                   // Log.d("Cookies", "Cookie cached: " + cookie.host + cookie.path + ":" + s);
+                    Log.d("Skandiabanken cookie", "Cookie string: " + s);
+                    putCookie(cookie);
                 }
             }
         }
@@ -140,11 +142,11 @@ public class HessianHttpProxyFactory extends HessianProxyFactory {
             String path = conn.getURL().getPath();
 
             while (path != null && 0 < path.length()) {
-                //Log.d("Cookies", "Host:+" + host +",Path:"+path);
+                Log.d("Skandiabanken cookie", "Host:+" + host +",Path:"+path);
                 Cookie cookie = getCookie(host, path);
                 if (cookie != null) {
                     conn.setRequestProperty("Cookie", cookie.value);
-                    //Log.d("Cookies", "Cookie set in request:" + cookie.value);
+                    Log.d("Skandiabanken cookie", "Cookie set in request:" + cookie.value);
                     break;
                 }
                 int i = path.lastIndexOf("/");
@@ -158,6 +160,11 @@ public class HessianHttpProxyFactory extends HessianProxyFactory {
 
 		protected Cookie getCookie(String host, String path) {
 			return HessianHttpProxy.cookieMap.get(host + path);
+		}
+
+		protected void putCookie(Cookie cookie) {
+            HessianHttpProxy.cookieMap.put(cookie.host + cookie.path, cookie);
+            Log.d("Skandiabanken cookie", "Cookie cached: " + cookie.host + cookie.path);
 		}
 	}
 }


### PR DESCRIPTION
Use the session cookie for all requests to smartrefill.se no mather the path in the cookie or in the request.
