### PR TITLE
Support to go back to main view from transaction view

### DIFF
--- a/app/src/main/java/com/liato/bankdroid/TransactionsActivity.java
+++ b/app/src/main/java/com/liato/bankdroid/TransactionsActivity.java
@@ -62,6 +62,12 @@ public class TransactionsActivity extends LockableActivity {
             ListView viewTransactionsList = (ListView) findViewById(R.id.lstTransactionsList);
             viewTransactionsList.setAdapter(adapter);
         }
+        findViewById(R.id.layBankHeader).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                finish();
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
This have been bugging me for so long, not being able to go back by clicking on the account name to go back when viewing transactions.