### PR TITLE
Add basic shell script which prints expired certificates

### DIFF
--- a/tools/print_expired_certificates
+++ b/tools/print_expired_certificates
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+for cert in `dirname $0`/../app/src/main/res/raw/*.pem; do
+  EXPIRE_DATE=`openssl x509 -in "$cert" -noout -enddate | sed -e 's/notAfter=\(.*\)/\1/g'`
+  if [ `date --date="$EXPIRE_DATE" "+%s"` -lt `date "+%s"` ]; then
+    echo `basename $cert`: $EXPIRE_DATE
+  fi
+done


### PR DESCRIPTION
I created a simple script to check for expired certificates. It runs on linux so depending on your development environment it may or it may not work.

It found some aging certificates so hopefully it's of some use:
```
cert_americanexpress_global.pem: Feb 8 23:59:59 2015 GMT
cert_bioklubben.pem: Aug 29 23:59:59 2014 GMT
cert_everydaycard.pem: Jun 1 23:59:59 2012 GMT
cert_mobilbanken.pem: Nov 7 23:59:59 2014 GMT
cert_osuuspankki.pem: Dec 12 23:59:59 2014 GMT
cert_osuuspankki_mobile.pem: Sep 13 23:59:59 2014 GMT
cert_plusgirot.pem: Jan 23 23:59:59 2015 GMT
cert_seb_web.pem: Jul 22 23:59:59 2014 GMT
```