### PR TITLE
Do not abort build on lint errors.

### DIFF
--- a/bankdroid-legacy/build.gradle
+++ b/bankdroid-legacy/build.gradle
@@ -16,6 +16,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    lintOptions {
+        abortOnError false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Fixes build error for `bankdroid-legacy` module