### PR TITLE
Remove banks that require BankId

### DIFF
--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/LegacyBankFactory.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/LegacyBankFactory.java
@@ -16,19 +16,12 @@ import com.liato.bankdroid.banking.banks.BlekingeTrafiken;
 import com.liato.bankdroid.banking.banks.BrummerKF;
 import com.liato.bankdroid.banking.banks.CSN;
 import com.liato.bankdroid.banking.banks.Chalmrest;
-import com.liato.bankdroid.banking.banks.Chevrolet;
 import com.liato.bankdroid.banking.banks.DanskeBank;
 import com.liato.bankdroid.banking.banks.DinersClub;
-import com.liato.bankdroid.banking.banks.Djurgarden;
 import com.liato.bankdroid.banking.banks.EasyCard;
-import com.liato.bankdroid.banking.banks.EurobonusMastercard;
-import com.liato.bankdroid.banking.banks.EurobonusMastercardDk;
-import com.liato.bankdroid.banking.banks.EurobonusMastercardNo;
-import com.liato.bankdroid.banking.banks.Eurocard;
 import com.liato.bankdroid.banking.banks.Everydaycard;
 import com.liato.bankdroid.banking.banks.FirstCard;
 import com.liato.bankdroid.banking.banks.ForexBank;
-import com.liato.bankdroid.banking.banks.Handelsbanken;
 import com.liato.bankdroid.banking.banks.Hemkop;
 import com.liato.bankdroid.banking.banks.IKEA;
 import com.liato.bankdroid.banking.banks.IkanoBank;
@@ -40,16 +33,12 @@ import com.liato.bankdroid.banking.banks.NordeaDK;
 import com.liato.bankdroid.banking.banks.Nordnet;
 import com.liato.bankdroid.banking.banks.Nordnetdirekt;
 import com.liato.bankdroid.banking.banks.OKQ8;
-import com.liato.bankdroid.banking.banks.Opel;
 import com.liato.bankdroid.banking.banks.Ostgotatrafiken;
 import com.liato.bankdroid.banking.banks.Osuuspankki;
 import com.liato.bankdroid.banking.banks.PayPal;
 import com.liato.bankdroid.banking.banks.PlusGirot;
 import com.liato.bankdroid.banking.banks.Preem;
-import com.liato.bankdroid.banking.banks.Quintessentially;
 import com.liato.bankdroid.banking.banks.ResursBank;
-import com.liato.bankdroid.banking.banks.SJPrio;
-import com.liato.bankdroid.banking.banks.Saab;
 import com.liato.bankdroid.banking.banks.Seat;
 import com.liato.bankdroid.banking.banks.SevenDay;
 import com.liato.bankdroid.banking.banks.Shell;
@@ -57,7 +46,6 @@ import com.liato.bankdroid.banking.banks.Skandiabanken;
 import com.liato.bankdroid.banking.banks.Skoda;
 import com.liato.bankdroid.banking.banks.SparbankenOresund;
 import com.liato.bankdroid.banking.banks.SparbankenSyd;
-import com.liato.bankdroid.banking.banks.Statoil;
 import com.liato.bankdroid.banking.banks.SupremeCard;
 import com.liato.bankdroid.banking.banks.SveaDirekt;
 import com.liato.bankdroid.banking.banks.SvenskaSpel;
@@ -68,7 +56,6 @@ import com.liato.bankdroid.banking.banks.Vasttrafik;
 import com.liato.bankdroid.banking.banks.Villabanken;
 import com.liato.bankdroid.banking.banks.Volkswagen;
 import com.liato.bankdroid.banking.banks.Volvofinans;
-import com.liato.bankdroid.banking.banks.Wallet;
 import com.liato.bankdroid.banking.banks.Zidisha;
 import com.liato.bankdroid.banking.banks.avanza.Avanza;
 import com.liato.bankdroid.banking.banks.bitcoin.Bitcoin;
@@ -79,7 +66,6 @@ import com.liato.bankdroid.banking.banks.lansforsakringar.Lansforsakringar;
 import com.liato.bankdroid.banking.banks.nordea.Nordea;
 import com.liato.bankdroid.banking.banks.payson.Payson;
 import com.liato.bankdroid.banking.banks.rikslunchen.Rikslunchen;
-import com.liato.bankdroid.banking.banks.seb.SEB;
 import com.liato.bankdroid.banking.banks.swedbank.Sparbankerna;
 import com.liato.bankdroid.banking.banks.swedbank.Swedbank;
 import com.liato.bankdroid.banking.exceptions.BankException;
@@ -105,14 +91,14 @@ public class LegacyBankFactory {
                 return new Lansforsakringar(context);
             case IBankTypes.ICABANKEN:
                 return new ICABanken(context);
-            case IBankTypes.HANDELSBANKEN:
-                return new Handelsbanken(context);
+            // case IBankTypes.HANDELSBANKEN:
+            //     return new Handelsbanken(context);
             case IBankTypes.COOP:
                 return new Coop(context);
             case IBankTypes.ICA:
                 return new ICA(context);
-            case IBankTypes.STATOIL:
-                return new Statoil(context);
+            // case IBankTypes.STATOIL:
+            //    return new Statoil(context);
             case IBankTypes.AVANZA:
                 return new Avanza(context);
             case IBankTypes.VILLABANKEN:
@@ -121,8 +107,8 @@ public class LegacyBankFactory {
                 return new AvanzaMini(context);
             case IBankTypes.OKQ8:
                 return new OKQ8(context);
-            case IBankTypes.EUROCARD:
-                return new Eurocard(context);
+            // case IBankTypes.EUROCARD:
+            //     return new Eurocard(context);
             case IBankTypes.FIRSTCARD:
                 return new FirstCard(context);
             case IBankTypes.PAYPAL:
@@ -131,24 +117,24 @@ public class LegacyBankFactory {
                 return new Payson(context);
             case IBankTypes.JOJO:
                 return new Jojo(context);
-            //case IBankTypes.STEAM:
+            // case IBankTypes.STEAM:
             //    return new Steam(context);
             case IBankTypes.DINERSCLUB:
                 return new DinersClub(context);
             case IBankTypes.IKANOBANK:
                 return new IkanoBank(context);
-            case IBankTypes.SASEUROBONUSMASTERCARD:
-                return new EurobonusMastercard(context);
-            case IBankTypes.SASEUROBONUSMASTERCARD_NO:
-                return new EurobonusMastercardNo(context);
-            case IBankTypes.SASEUROBONUSMASTERCARD_DK:
-                return new EurobonusMastercardDk(context);
+            //  case IBankTypes.SASEUROBONUSMASTERCARD:
+            //      return new EurobonusMastercard(context);
+            //  case IBankTypes.SASEUROBONUSMASTERCARD_NO:
+            //      return new EurobonusMastercardNo(context);
+            //  case IBankTypes.SASEUROBONUSMASTERCARD_DK:
+            //      return new EurobonusMastercardDk(context);
             case IBankTypes.RIKSLUNCHEN:
                 return new Rikslunchen(context);
             case IBankTypes.HEMKOP:
                 return new Hemkop(context);
-            case IBankTypes.SEB:
-                return new SEB(context);
+            // case IBankTypes.SEB:
+            //     return new SEB(context);
             case IBankTypes.NORDNET:
                 return new Nordnet(context);
             case IBankTypes.SEVENDAY:
@@ -165,20 +151,20 @@ public class LegacyBankFactory {
                 return new AmericanExpress(context);
             case IBankTypes.MCDONALDS:
                 return new McDonalds(context);
-            case IBankTypes.SAAB:
-                return new Saab(context);
-            case IBankTypes.WALLET:
-                return new Wallet(context);
-            case IBankTypes.CHEVROLET:
-                return new Chevrolet(context);
-            case IBankTypes.SJPRIO:
-                return new SJPrio(context);
-            case IBankTypes.OPEL:
-                return new Opel(context);
-            case IBankTypes.DJURGARDEN:
-                return new Djurgarden(context);
-            case IBankTypes.QUINTESSENTIALLY:
-                return new Quintessentially(context);
+            // case IBankTypes.SAAB:
+            //     return new Saab(context);
+            // case IBankTypes.WALLET:
+            //     return new Wallet(context);
+            //  case IBankTypes.CHEVROLET:
+            //      return new Chevrolet(context);
+            //  case IBankTypes.SJPRIO:
+            //      return new SJPrio(context);
+            //  case IBankTypes.OPEL:
+            //      return new Opel(context);
+            // case IBankTypes.DJURGARDEN:
+            //     return new Djurgarden(context);
+            //   case IBankTypes.QUINTESSENTIALLY:
+            //       return new Quintessentially(context);
             case IBankTypes.PLUSGIROT:
                 return new PlusGirot(context);
             case IBankTypes.SHELL:
@@ -264,26 +250,26 @@ public class LegacyBankFactory {
         banks.add(new Nordea(context));
         banks.add(new ICABanken(context));
         banks.add(new Lansforsakringar(context));
-        banks.add(new Handelsbanken(context));
+        // banks.add(new Handelsbanken(context));
         banks.add(new Coop(context));
         banks.add(new ICA(context));
-        banks.add(new Statoil(context));
+        // banks.add(new Statoil(context));
         banks.add(new Avanza(context));
         banks.add(new Villabanken(context));
         banks.add(new AvanzaMini(context));
         banks.add(new OKQ8(context));
-        banks.add(new Eurocard(context));
+        // banks.add(new Eurocard(context));
         banks.add(new FirstCard(context));
         banks.add(new PayPal(context));
         banks.add(new Payson(context));
         banks.add(new Jojo(context));
-        //banks.add(new Steam(context));
+        // banks.add(new Steam(context));
         banks.add(new DinersClub(context));
         banks.add(new IkanoBank(context));
-        banks.add(new EurobonusMastercard(context));
+        // banks.add(new EurobonusMastercard(context));
         banks.add(new Rikslunchen(context));
         banks.add(new Hemkop(context));
-        banks.add(new SEB(context));
+        // banks.add(new SEB(context));
         banks.add(new Nordnet(context));
         banks.add(new SevenDay(context));
         banks.add(new Osuuspankki(context));
@@ -291,19 +277,19 @@ public class LegacyBankFactory {
         banks.add(new CSN(context));
         banks.add(new ResursBank(context));
         banks.add(new McDonalds(context));
-        banks.add(new SJPrio(context));
+        // banks.add(new SJPrio(context));
         banks.add(new SparbankenSyd(context));
-//        banks.add(new SparbankenOresund(context));
-        banks.add(new Opel(context));
+        // banks.add(new SparbankenOresund(context));
+        // banks.add(new Opel(context));
         banks.add(new Skandiabanken(context));
         banks.add(new AmericanExpress(context));
         banks.add(new PlusGirot(context));
         banks.add(new Nordnetdirekt(context));
-        banks.add(new Saab(context));
-        banks.add(new Wallet(context));
-        banks.add(new Chevrolet(context));
-        banks.add(new Djurgarden(context));
-        banks.add(new Quintessentially(context));
+        // banks.add(new Saab(context));
+        // banks.add(new Wallet(context));
+        // banks.add(new Chevrolet(context));
+        // banks.add(new Djurgarden(context));
+        // banks.add(new Quintessentially(context));
         banks.add(new Shell(context));
         banks.add(new Volkswagen(context));
         banks.add(new Audi(context));
@@ -311,7 +297,7 @@ public class LegacyBankFactory {
         banks.add(new Seat(context));
         banks.add(new Skoda(context));
         banks.add(new IKEA(context));
-//        banks.add(new DanskeBank(context));
+        // banks.add(new DanskeBank(context));
         banks.add(new NordeaDK(context));
         banks.add(new Vasttrafik(context));
         banks.add(new Everydaycard(context));
@@ -326,9 +312,9 @@ public class LegacyBankFactory {
         banks.add(new Zidisha(context));
         banks.add(new BetterGlobe(context));
         banks.add(new ForexBank(context));
-        banks.add(new EurobonusMastercardNo(context));
+        // banks.add(new EurobonusMastercardNo(context));
         banks.add(new Bitcoin(context));
-        banks.add(new EurobonusMastercardDk(context));
+        // banks.add(new EurobonusMastercardDk(context));
         banks.add(new SveaDirekt(context));
         banks.add(new SupremeCard(context));
         banks.add(new Sparbankerna(context));


### PR DESCRIPTION
Removes the following banks because they requires SMS or BankId to login.

* Handelsbanken
* SEB
* Chevrolet
* Djurgarden
* EurobonusMastercard
* EurobonusMastercardDk
* EurobonusMastercardNo
* Eurocard
* Opel
* Quintessentially
* SJPrio
* Saab
* Statoil
* Wallet