### PR TITLE
Adds Android codestyle template for AndroidStudio.

### DIFF
--- a/config/ide/androidstudio/AndroidStyle.xml
+++ b/config/ide/androidstudio/AndroidStyle.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<code_scheme name="AndroidStyle">
+    <option name="JAVA_INDENT_OPTIONS">
+        <value>
+            <option name="INDENT_SIZE" value="4"/>
+            <option name="CONTINUATION_INDENT_SIZE" value="8"/>
+            <option name="TAB_SIZE" value="8"/>
+            <option name="USE_TAB_CHARACTER" value="false"/>
+            <option name="SMART_TABS" value="false"/>
+            <option name="LABEL_INDENT_SIZE" value="0"/>
+            <option name="LABEL_INDENT_ABSOLUTE" value="false"/>
+            <option name="USE_RELATIVE_INDENTS" value="false"/>
+        </value>
+    </option>
+    <option name="FIELD_NAME_PREFIX" value="m"/>
+    <option name="STATIC_FIELD_NAME_PREFIX" value="m"/>
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="9999"/>
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="9999"/>
+    <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+            <package name="com.google" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="com" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="junit" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="net" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="org" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="android" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="java" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="javax" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="" withSubpackages="true" static="true"/>
+        </value>
+    </option>
+    <option name="RIGHT_MARGIN" value="100"/>
+    <option name="JD_P_AT_EMPTY_LINES" value="false"/>
+    <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true"/>
+    <option name="JD_KEEP_EMPTY_PARAMETER" value="false"/>
+    <option name="JD_KEEP_EMPTY_EXCEPTION" value="false"/>
+    <option name="JD_KEEP_EMPTY_RETURN" value="false"/>
+    <option name="JD_PRESERVE_LINE_FEEDS" value="true"/>
+    <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false"/>
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+    <option name="BLANK_LINES_AROUND_FIELD" value="1"/>
+    <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1"/>
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+    <option name="ALIGN_MULTILINE_FOR" value="false"/>
+    <option name="CALL_PARAMETERS_WRAP" value="1"/>
+    <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+    <option name="EXTENDS_LIST_WRAP" value="1"/>
+    <option name="THROWS_LIST_WRAP" value="1"/>
+    <option name="EXTENDS_KEYWORD_WRAP" value="1"/>
+    <option name="THROWS_KEYWORD_WRAP" value="1"/>
+    <option name="METHOD_CALL_CHAIN_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+    <option name="TERNARY_OPERATION_WRAP" value="1"/>
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
+    <option name="FOR_STATEMENT_WRAP" value="1"/>
+    <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
+    <option name="ASSIGNMENT_WRAP" value="1"/>
+    <option name="PLACE_ASSIGNMENT_SIGN_ON_NEXT_LINE" value="true"/>
+    <option name="WRAP_COMMENTS" value="true"/>
+    <option name="IF_BRACE_FORCE" value="3"/>
+    <option name="DOWHILE_BRACE_FORCE" value="3"/>
+    <option name="WHILE_BRACE_FORCE" value="3"/>
+    <option name="FOR_BRACE_FORCE" value="3"/>
+    <ADDITIONAL_INDENT_OPTIONS fileType="css">
+        <option name="INDENT_SIZE" value="4"/>
+        <option name="CONTINUATION_INDENT_SIZE" value="8"/>
+        <option name="TAB_SIZE" value="4"/>
+        <option name="USE_TAB_CHARACTER" value="false"/>
+        <option name="SMART_TABS" value="false"/>
+        <option name="LABEL_INDENT_SIZE" value="0"/>
+        <option name="LABEL_INDENT_ABSOLUTE" value="false"/>
+        <option name="USE_RELATIVE_INDENTS" value="false"/>
+    </ADDITIONAL_INDENT_OPTIONS>
+    <ADDITIONAL_INDENT_OPTIONS fileType="java">
+        <option name="INDENT_SIZE" value="4"/>
+        <option name="CONTINUATION_INDENT_SIZE" value="8"/>
+        <option name="TAB_SIZE" value="8"/>
+        <option name="USE_TAB_CHARACTER" value="false"/>
+        <option name="SMART_TABS" value="false"/>
+        <option name="LABEL_INDENT_SIZE" value="0"/>
+        <option name="LABEL_INDENT_ABSOLUTE" value="false"/>
+        <option name="USE_RELATIVE_INDENTS" value="false"/>
+    </ADDITIONAL_INDENT_OPTIONS>
+    <ADDITIONAL_INDENT_OPTIONS fileType="js">
+        <option name="INDENT_SIZE" value="4"/>
+        <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+        <option name="TAB_SIZE" value="4"/>
+        <option name="USE_TAB_CHARACTER" value="false"/>
+        <option name="SMART_TABS" value="false"/>
+        <option name="LABEL_INDENT_SIZE" value="0"/>
+        <option name="LABEL_INDENT_ABSOLUTE" value="false"/>
+        <option name="USE_RELATIVE_INDENTS" value="false"/>
+    </ADDITIONAL_INDENT_OPTIONS>
+    <ADDITIONAL_INDENT_OPTIONS fileType="jsp">
+        <option name="INDENT_SIZE" value="4"/>
+        <option name="CONTINUATION_INDENT_SIZE" value="8"/>
+        <option name="TAB_SIZE" value="4"/>
+        <option name="USE_TAB_CHARACTER" value="false"/>
+        <option name="SMART_TABS" value="false"/>
+        <option name="LABEL_INDENT_SIZE" value="0"/>
+        <option name="LABEL_INDENT_ABSOLUTE" value="false"/>
+        <option name="USE_RELATIVE_INDENTS" value="false"/>
+    </ADDITIONAL_INDENT_OPTIONS>
+    <ADDITIONAL_INDENT_OPTIONS fileType="sql">
+        <option name="INDENT_SIZE" value="2"/>
+        <option name="CONTINUATION_INDENT_SIZE" value="8"/>
+        <option name="TAB_SIZE" value="4"/>
+        <option name="USE_TAB_CHARACTER" value="false"/>
+        <option name="SMART_TABS" value="false"/>
+        <option name="LABEL_INDENT_SIZE" value="0"/>
+        <option name="LABEL_INDENT_ABSOLUTE" value="false"/>
+        <option name="USE_RELATIVE_INDENTS" value="false"/>
+    </ADDITIONAL_INDENT_OPTIONS>
+    <ADDITIONAL_INDENT_OPTIONS fileType="xml">
+        <option name="INDENT_SIZE" value="4"/>
+        <option name="CONTINUATION_INDENT_SIZE" value="8"/>
+        <option name="TAB_SIZE" value="4"/>
+        <option name="USE_TAB_CHARACTER" value="false"/>
+        <option name="SMART_TABS" value="false"/>
+        <option name="LABEL_INDENT_SIZE" value="0"/>
+        <option name="LABEL_INDENT_ABSOLUTE" value="false"/>
+        <option name="USE_RELATIVE_INDENTS" value="false"/>
+    </ADDITIONAL_INDENT_OPTIONS>
+    <ADDITIONAL_INDENT_OPTIONS fileType="yml">
+        <option name="INDENT_SIZE" value="2"/>
+        <option name="CONTINUATION_INDENT_SIZE" value="8"/>
+        <option name="TAB_SIZE" value="4"/>
+        <option name="USE_TAB_CHARACTER" value="false"/>
+        <option name="SMART_TABS" value="false"/>
+        <option name="LABEL_INDENT_SIZE" value="0"/>
+        <option name="LABEL_INDENT_ABSOLUTE" value="false"/>
+        <option name="USE_RELATIVE_INDENTS" value="false"/>
+    </ADDITIONAL_INDENT_OPTIONS>
+    <codeStyleSettings language="JavaScript">
+        <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false"/>
+        <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+        <option name="BLANK_LINES_AROUND_FIELD" value="1"/>
+        <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1"/>
+        <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+        <option name="ALIGN_MULTILINE_FOR" value="false"/>
+        <option name="CALL_PARAMETERS_WRAP" value="1"/>
+        <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+        <option name="EXTENDS_LIST_WRAP" value="1"/>
+        <option name="THROWS_LIST_WRAP" value="1"/>
+        <option name="EXTENDS_KEYWORD_WRAP" value="1"/>
+        <option name="THROWS_KEYWORD_WRAP" value="1"/>
+        <option name="METHOD_CALL_CHAIN_WRAP" value="1"/>
+        <option name="BINARY_OPERATION_WRAP" value="1"/>
+        <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+        <option name="TERNARY_OPERATION_WRAP" value="1"/>
+        <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
+        <option name="FOR_STATEMENT_WRAP" value="1"/>
+        <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
+        <option name="ASSIGNMENT_WRAP" value="1"/>
+        <option name="PLACE_ASSIGNMENT_SIGN_ON_NEXT_LINE" value="true"/>
+        <option name="WRAP_COMMENTS" value="true"/>
+        <option name="IF_BRACE_FORCE" value="3"/>
+        <option name="DOWHILE_BRACE_FORCE" value="3"/>
+        <option name="WHILE_BRACE_FORCE" value="3"/>
+        <option name="FOR_BRACE_FORCE" value="3"/>
+        <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
+    </codeStyleSettings>
+</code_scheme>


### PR DESCRIPTION
Adds codestyle template for AndroidStudio.
Use the template:

1. Place `AndroidStyle.xml` in your Android Studio `/codestyles` directory (e.g., `%userprofile%\.AndroidStudio\config\codestyles`, or `~/Library/Preferences/AndroidStudio/codestyles/` on OS X)
2. Restart Android Studio.
3. Go to "File->Settings->Code Style", and under "Scheme" select "AndroidStyle" and click "Ok".
4. Right-click on the files that contain your contributions and select "Reformat Code", check "Optimize imports", and select "Run".