### PR TITLE
Shorten Amex card titles

### DIFF
--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/AmericanExpress.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/AmericanExpress.java
@@ -148,7 +148,10 @@ public class AmericanExpress extends Bank {
              * 4: Amount                1.111,11 kr
              * 
              */
-            accounts.add(new Account(Html.fromHtml(matcher.group(3)).toString().trim(),
+            accounts.add(new Account(Html.fromHtml(matcher.group(3)).toString()
+                    .replace("American Express", "Amex")
+                    .replace("EuroBonus", "EB")
+                    .trim(),
                     Helpers.parseBalance(matcher.group(4)).negate(),
                     matcher.group(2).trim()));
             balance = balance.add(Helpers.parseBalance(matcher.group(4)).negate());


### PR DESCRIPTION
Many (most?) of the Amex card titles parsed from the site end up
being very long, which makes the amount included in the notifications
end up outside the screen.

Replace "American Express" with "Amex" and "EuroBonus" with "EB" in
order to shorten these down, while keeping them unique and easy
to identify.