### PR TITLE
Fix widget not refreshing on auto updates

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 v1.9.10.8
 * Add a Volatile account to the Test Bank that always changes its balance.
+* Fix widget not updating when the balance change was lower than the notification threshold.
 
 v1.9.10.7 (2016-08-18)
 * Update certificates for AmericanExpress and Coop

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -42,11 +42,12 @@ Development
   Mikael Eriksson                   https://github.com/mikaeler
   Mikael Auno                       https://github.com/auno
   robho                             https://github.com/robho
+  Johan Walles                      https://github.com/walles
 
 
   Stats at:
   https://github.com/liato/android-bankdroid/graphs/contributors?type=a
- 
+
 --------------------------------------------------------------------------------
 Beta testing
 --------------------------------------------------------------------------------

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,4 +80,7 @@ dependencies {
     compile('com.crashlytics.sdk.android:crashlytics:2.2.1@aar') {
         transitive = true;
     }
+
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-core:1.10.19'
 }

--- a/app/src/test/java/com/liato/bankdroid/appwidget/DataRetrieverTaskTest.java
+++ b/app/src/test/java/com/liato/bankdroid/appwidget/DataRetrieverTaskTest.java
@@ -1,0 +1,118 @@
+package com.liato.bankdroid.appwidget;
+
+import com.liato.bankdroid.banking.Account;
+import com.liato.bankdroid.banking.Bank;
+import com.liato.bankdroid.db.DBAdapter;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DataRetrieverTaskTest {
+    private static class TestableBank extends Bank {
+        private final int balanceBeforeUpdate;
+        private final int balanceAfterUpdate;
+        private boolean hasUpdated = false;
+
+        public TestableBank(int balanceBeforeUpdate, int balanceAfterUpdate) {
+            super(Mockito.mock(Context.class));
+
+            this.balanceBeforeUpdate = balanceBeforeUpdate;
+            this.balanceAfterUpdate = balanceAfterUpdate;
+        }
+
+        @Override
+        public void update() {
+            hasUpdated = true;
+        }
+
+        @Override
+        public ArrayList<Account> getAccounts() {
+            int balance;
+            if (hasUpdated) {
+                balance = balanceAfterUpdate;
+            } else {
+                balance = balanceBeforeUpdate;
+            }
+
+            Account account = Mockito.mock(Account.class);
+            Mockito.when(account.getBalance()).thenReturn(BigDecimal.valueOf(balance));
+
+            ArrayList<Account> accounts = new ArrayList<>();
+            accounts.add(account);
+
+            return accounts;
+        }
+
+        @Override
+        public BigDecimal getBalance() {
+            return getAccounts().get(0).getBalance();
+        }
+    }
+
+    private static class TestableDataRetrieverTask extends AutoRefreshService.DataRetrieverTask {
+        private final Bank bank;
+        private boolean hasRefreshedWidget = false;
+
+        private TestableDataRetrieverTask(
+                AutoRefreshService autoRefreshService, SharedPreferences prefs, Bank bank) {
+            super(autoRefreshService, prefs);
+
+            this.bank = bank;
+        }
+
+        @Override
+        protected List<Bank> getBanks() {
+            List<Bank> returnMe = new ArrayList<>();
+            returnMe.add(bank);
+            return returnMe;
+        }
+
+        @NonNull
+        @Override
+        protected DBAdapter getDBAdapter() {
+            return Mockito.mock(DBAdapter.class);
+        }
+
+        @Override
+        protected void sendWidgetRefresh() {
+            hasRefreshedWidget = true;
+        }
+    }
+
+    @Test
+    public void testIncreaseLessThanNotificationThreshold() throws Exception {
+        AutoRefreshService autoRefreshService = Mockito.mock(AutoRefreshService.class);
+
+        SharedPreferences prefs = Mockito.mock(SharedPreferences.class);
+        Mockito.when(prefs.getString("notify_min_delta", "0")).thenReturn("300");
+
+        TestableDataRetrieverTask testMe =
+                new TestableDataRetrieverTask(autoRefreshService, prefs, new TestableBank(100, 200));
+        testMe.doInBackground();
+
+        Assert.assertTrue("Widget should have been refreshed", testMe.hasRefreshedWidget);
+    }
+
+    @Test
+    public void testNoChange() throws Exception {
+        AutoRefreshService autoRefreshService = Mockito.mock(AutoRefreshService.class);
+
+        SharedPreferences prefs = Mockito.mock(SharedPreferences.class);
+        Mockito.when(prefs.getString("notify_min_delta", "0")).thenReturn("0");
+
+        TestableDataRetrieverTask testMe =
+                new TestableDataRetrieverTask(autoRefreshService, prefs, new TestableBank(100, 100));
+        testMe.doInBackground();
+
+        Assert.assertFalse("Widget shouldn't have been refreshed", testMe.hasRefreshedWidget);
+    }
+}


### PR DESCRIPTION
Before this change:
* when the banks were auto updated
* and the bank's balance change was lower than the notification
  threshold
... then the widget wasn't updated.

With this change in place the widget is actually updated even in this
case.

This change also adds unit testing of the auto update data retrieval
code.