### PR TITLE
Fix "./gradlew check" task dependencies

### DIFF
--- a/config/quality/quality.gradle
+++ b/config/quality/quality.gradle
@@ -30,7 +30,7 @@ android {
     }
 }
 
-task findbugs(type: FindBugs) {
+task findbugs(type: FindBugs, dependsOn: 'compileDebugSources') {
     effort = "max"
     reportLevel = "high"
     excludeFilter = new File("${project.rootDir}/config/quality/findbugs/findbugs-filter.xml")


### PR DESCRIPTION
Before this change, just doing `./gradlew check` would fail because
FindBugs required `assembleDebug` to run first.

This change tells Gradle about this dependency and enables one to do
`./gradlew check` without doing `assembleDebug` first.