### PR TITLE
Widget: Replace warning symbol with strikethrough

### DIFF
--- a/app/src/main/java/com/liato/bankdroid/LockableActivity.java
+++ b/app/src/main/java/com/liato/bankdroid/LockableActivity.java
@@ -47,8 +47,6 @@ public class LockableActivity extends ActionBarActivity {
 
     private SharedPreferences mPrefs;
 
-    private Editor mEditor;
-
     private LockPatternUtils mLockPatternUtils;
 
     private boolean mHasLoaded = false;
@@ -240,9 +238,9 @@ public class LockableActivity extends ActionBarActivity {
     }
 
     private void writeLockTime(long time) {
-        mEditor = mPrefs.edit();
-        mEditor.putLong("locked_at", time);
-        mEditor.commit();
+        Editor editor = mPrefs.edit();
+        editor.putLong("locked_at", time);
+        editor.apply();
     }
 
     protected void onActivityResult(int requestCode, int resultCode,

--- a/app/src/main/java/com/liato/bankdroid/LockablePreferenceActivity.java
+++ b/app/src/main/java/com/liato/bankdroid/LockablePreferenceActivity.java
@@ -35,8 +35,6 @@ public class LockablePreferenceActivity extends PreferenceActivity {
 
     private SharedPreferences mPrefs;
 
-    private Editor mEditor;
-
     private LockPatternUtils mLockPatternUtils;
 
     private boolean mHasLoaded = false;
@@ -67,7 +65,7 @@ public class LockablePreferenceActivity extends PreferenceActivity {
         If this activity never loaded set the lock time to
         10 seconds ago.
         This is to prevent the following scenario:
-            1. Activity Starts 
+            1. Activity Starts
             2. Lock screen is displayed
             3. User presses the home button
             4. "lock time" is set in onPause to when the home button was pressed
@@ -111,9 +109,9 @@ public class LockablePreferenceActivity extends PreferenceActivity {
     }
 
     private void writeLockTime(long time) {
-        mEditor = mPrefs.edit();
-        mEditor.putLong("locked_at", time);
-        mEditor.commit();
+        Editor editor = mPrefs.edit();
+        editor.putLong("locked_at", time);
+        editor.apply();
     }
 
     protected boolean isLockEnabled() {
@@ -121,9 +119,9 @@ public class LockablePreferenceActivity extends PreferenceActivity {
     }
 
     protected void setLockEnabled(boolean enabled) {
-        mEditor = mPrefs.edit();
-        mEditor.putBoolean("lock_enabled", enabled);
-        mEditor.commit();
+        Editor editor = mPrefs.edit();
+        editor.putBoolean("lock_enabled", enabled);
+        editor.apply();
     }
 
     protected void onActivityResult(int requestCode, int resultCode,

--- a/app/src/main/java/com/liato/bankdroid/PairApplicationsActivity.java
+++ b/app/src/main/java/com/liato/bankdroid/PairApplicationsActivity.java
@@ -51,7 +51,7 @@ public class PairApplicationsActivity extends LockableActivity {
 
             // Commit to preferences
             editor.putString("content_provider_api_key", genKey.toUpperCase());
-            editor.commit();
+            editor.apply();
         }
     }
 
@@ -112,7 +112,7 @@ public class PairApplicationsActivity extends LockableActivity {
         SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(ctx);
         Editor editor = pref.edit();
         editor.putBoolean("content_provider_enabled", true);
-        editor.commit();
+        editor.apply();
         String apiKey;
 
         try {

--- a/app/src/main/java/com/liato/bankdroid/adapters/AccountsAdapter.java
+++ b/app/src/main/java/com/liato/bankdroid/adapters/AccountsAdapter.java
@@ -100,7 +100,8 @@ public class AccountsAdapter extends BaseAdapter {
                 .setText(Helpers.formatBalance(bank.getBalance(),
                         bank.getCurrency(),
                         prefs.getBoolean("round_balance", false) || !bank.getDisplayDecimals(),
-                        bank.getDecimalFormatter()));
+                        bank.getDecimalFormatter(),
+                        false));
         icon.setImageResource(bank.getImageResource());
         ImageView warning = (ImageView) convertView.findViewById(R.id.imgWarning);
         if (bank.isDisabled()) {
@@ -131,7 +132,8 @@ public class AccountsAdapter extends BaseAdapter {
                         account.getCurrency(),
                         prefs.getBoolean("round_balance", false) || !account.getBank()
                                 .getDisplayDecimals(),
-                        account.getBank().getDecimalFormatter()));
+                        account.getBank().getDecimalFormatter(),
+                        false));
         if (account.isHidden()) {
             txtAccountName.setTextColor(Color.argb(255, 191, 191, 191));
             txtBalance.setTextColor(Color.argb(255, 191, 191, 191));

--- a/app/src/main/java/com/liato/bankdroid/appwidget/AutoRefreshService.java
+++ b/app/src/main/java/com/liato/bankdroid/appwidget/AutoRefreshService.java
@@ -424,7 +424,7 @@ public class AutoRefreshService extends Service {
             }
             Editor edit = prefs.edit();
             edit.putLong("autoupdates_last_update", System.currentTimeMillis());
-            edit.commit();
+            edit.apply();
             autoRefreshService.stopSelf();
         }
     }

--- a/app/src/main/java/com/liato/bankdroid/appwidget/BankdroidWidgetProvider.java
+++ b/app/src/main/java/com/liato/bankdroid/appwidget/BankdroidWidgetProvider.java
@@ -78,7 +78,7 @@ public abstract class BankdroidWidgetProvider extends AppWidgetProvider {
         SharedPreferences prefs = context.getSharedPreferences("widget_prefs", 0);
         Editor e = prefs.edit();
         e.putBoolean("widget_unblurred_" + appWidgetId, true);
-        e.commit();
+        e.apply();
 
         RemoteViews views = buildAppWidget(context, appWidgetManager, appWidgetId);
         if (views != null) {
@@ -95,7 +95,7 @@ public abstract class BankdroidWidgetProvider extends AppWidgetProvider {
         SharedPreferences prefs = context.getSharedPreferences("widget_prefs", 0);
         Editor e = prefs.edit();
         e.remove("widget_unblurred_" + appWidgetId);
-        e.commit();
+        e.apply();
         RemoteViews views = buildAppWidget(context, appWidgetManager, appWidgetId);
         if (views != null) {
             views.setViewVisibility(R.id.imgBalanceblur, View.VISIBLE);
@@ -158,13 +158,9 @@ public abstract class BankdroidWidgetProvider extends AppWidgetProvider {
         views.setTextViewText(R.id.txtWidgetAccountbalance,
                 Helpers.formatBalance(account.getBalance(), account.getCurrency(),
                         defprefs.getBoolean("round_widget_balance", false),
-                        bank.getDecimalFormatter()));
+                        bank.getDecimalFormatter(),
+                        bank.isDisabled()));
         views.setImageViewResource(R.id.imgWidgetIcon, bank.getImageResource());
-        if (bank.isDisabled()) {
-            views.setViewVisibility(R.id.frmWarning, View.VISIBLE);
-        } else {
-            views.setViewVisibility(R.id.frmWarning, View.INVISIBLE);
-        }
         Intent intent = new Intent(context, MainActivity.class);
         PendingIntent pendingIntent;
 
@@ -236,7 +232,6 @@ public abstract class BankdroidWidgetProvider extends AppWidgetProvider {
         views.setTextViewText(R.id.txtWidgetAccountname, "");
         views.setTextViewText(R.id.txtWidgetAccountbalance, "ERROR");
         views.setImageViewResource(R.id.imgWidgetIcon, R.drawable.icon_large);
-        views.setViewVisibility(R.id.frmWarning, View.VISIBLE);
 
         Intent intent = new Intent(context, MainActivity.class);
         PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, 0);
@@ -379,7 +374,7 @@ public abstract class BankdroidWidgetProvider extends AppWidgetProvider {
                     return null;
                 }
                 long bankId = WidgetConfigureActivity.getBankId(context, appWidgetId);
-                Bank bank = BankFactory.bankFromDb(new Long(bankId), context, true);
+                Bank bank = BankFactory.bankFromDb(bankId, context, true);
                 if (bank == null) {
                     return null;
                 }

--- a/app/src/main/java/com/liato/bankdroid/appwidget/WidgetConfigureActivity.java
+++ b/app/src/main/java/com/liato/bankdroid/appwidget/WidgetConfigureActivity.java
@@ -56,7 +56,7 @@ public class WidgetConfigureActivity extends LockableActivity {
         SharedPreferences.Editor prefs = context.getSharedPreferences("widget_prefs", 0).edit();
         prefs.putString(WIDGET_PREFIX + appWidgetId, accountId);
         prefs.putLong(WIDGET_PREFIX + appWidgetId + "_bankid", bankId);
-        prefs.commit();
+        prefs.apply();
     }
 
     public static String getAccountId(Context context, int appWidgetId) {
@@ -73,7 +73,7 @@ public class WidgetConfigureActivity extends LockableActivity {
         SharedPreferences.Editor prefs = context.getSharedPreferences("widget_prefs", 0).edit();
         prefs.remove(WIDGET_PREFIX + appWidgetId);
         prefs.remove(WIDGET_PREFIX + appWidgetId + "_bankid");
-        prefs.commit();
+        prefs.apply();
     }
 
     @Override
@@ -114,7 +114,7 @@ public class WidgetConfigureActivity extends LockableActivity {
                         .edit();
                 prefs.putBoolean("transperant_background" + mAppWidgetId,
                         ((CheckBox) findViewById(R.id.chkTransperantBackground)).isChecked());
-                prefs.commit();
+                prefs.apply();
                 // Push widget update to surface with newly set prefix
                 AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(context);
                 BankdroidWidgetProvider.updateAppWidget(context, appWidgetManager,

--- a/app/src/main/java/com/liato/bankdroid/db/DBAdapter.java
+++ b/app/src/main/java/com/liato/bankdroid/db/DBAdapter.java
@@ -190,7 +190,7 @@ public class DBAdapter {
                 vals.put("bankid", bankId);
                 vals.put("balance", acc.getBalance().toPlainString());
                 vals.put("name", acc.getName());
-                vals.put("id", new Long(bankId).toString() + "_" + acc.getId());
+                vals.put("id", bankId + "_" + acc.getId());
                 vals.put("hidden", acc.isHidden() ? 1 : 0);
                 vals.put("notify", acc.isNotify() ? 1 : 0);
                 vals.put("currency", acc.getCurrency());
@@ -200,14 +200,14 @@ public class DBAdapter {
                 if (acc.getAliasfor() == null || acc.getAliasfor().length() == 0) {
                     List<Transaction> transactions = acc.getTransactions();
                     if (transactions != null && !transactions.isEmpty()) {
-                        deleteTransactions(new Long(bankId).toString() + "_" + acc.getId());
+                        deleteTransactions(bankId + "_" + acc.getId());
                         for (Transaction transaction : transactions) {
                             ContentValues transvals = new ContentValues();
                             transvals.put("transdate", transaction.getDate());
                             transvals.put("btransaction", transaction.getTransaction());
                             transvals.put("amount", transaction.getAmount().toPlainString());
                             transvals.put("account",
-                                    new Long(bankId).toString() + "_" + acc.getId());
+                                    bankId + "_" + acc.getId());
                             transvals.put("currency", transaction.getCurrency());
                             mDb.insert("transactions", null, transvals);
                         }
@@ -239,7 +239,7 @@ public class DBAdapter {
     }
 
     public Cursor getBank(long bankId) {
-        return getBank(new Long(bankId).toString());
+        return getBank(Long.toString(bankId));
     }
 
     public Cursor getAccount(String id) {

--- a/app/src/main/java/com/liato/bankdroid/lockpattern/LockPatternUtils.java
+++ b/app/src/main/java/com/liato/bankdroid/lockpattern/LockPatternUtils.java
@@ -372,7 +372,7 @@ public class LockPatternUtils {
     private void setBoolean(String systemSettingKey, boolean enabled) {
         Editor editor = mPrefs.edit();
         editor.putBoolean(systemSettingKey, enabled);
-        editor.commit();
+        editor.apply();
     }
 
     private long getLong(String systemSettingKey, long def) {
@@ -382,6 +382,6 @@ public class LockPatternUtils {
     private void setLong(String systemSettingKey, long value) {
         Editor editor = mPrefs.edit();
         editor.putLong(systemSettingKey, value);
-        editor.commit();
+        editor.apply();
     }
 }

--- a/app/src/main/res/layout/widget.xml
+++ b/app/src/main/res/layout/widget.xml
@@ -105,21 +105,5 @@
 				android:minWidth="17dp"
 				android:visibility="visible"></ProgressBar>
 		</FrameLayout>
-
-
-		<FrameLayout
-			android:layout_height="wrap_content"
-			android:id="@+id/frmWarning"
-			android:layout_width="fill_parent"
-			android:visibility="invisible">
-			<ImageView
-				android:id="@+id/imgWarning"
-				android:adjustViewBounds="true"
-				android:layout_gravity="bottom|right"
-				android:layout_height="fill_parent"
-				android:src="@drawable/indicator_input_error"
-				android:scaleType="fitXY"
-				android:layout_width="wrap_content"></ImageView>
-		</FrameLayout>
 	</LinearLayout>
 </RelativeLayout>

--- a/app/src/main/res/layout/widget_large.xml
+++ b/app/src/main/res/layout/widget_large.xml
@@ -84,31 +84,6 @@
 </RelativeLayout>
 	</RelativeLayout>
 	<RelativeLayout
-			android:layout_width="wrap_content"
-		android:layout_height="wrap_content"
-		android:layout_alignParentRight="true"
-		android:paddingTop="15dp"
-		android:paddingRight="11dp">
-		<FrameLayout
-			android:layout_height="wrap_content"
-			android:id="@+id/frmWarning"
-			android:layout_width="wrap_content"
-			android:visibility="invisible">
-			<ImageView
-				android:id="@+id/imgWarning"
-				android:adjustViewBounds="true"
-				android:layout_height="fill_parent"
-				android:src="@drawable/indicator_input_error"
-				android:scaleType="fitXY"
-				android:layout_width="wrap_content"
-				android:layout_gravity="top|right"
-				android:maxWidth="17dp"
-				android:maxHeight="17dp"
-				android:minHeight="17dp"
-				android:minWidth="17dp"></ImageView>
-		</FrameLayout>
-	</RelativeLayout>
-	<RelativeLayout
 		android:layout_width="wrap_content"
 		android:layout_height="wrap_content"
 		android:layout_alignTop="@+id/RelativeLayout02"

--- a/app/src/main/res/layout/widget_large_transparent.xml
+++ b/app/src/main/res/layout/widget_large_transparent.xml
@@ -82,31 +82,6 @@
 		</RelativeLayout>
 	</RelativeLayout>
 	<RelativeLayout
-			android:layout_width="wrap_content"
-		android:layout_height="wrap_content"
-		android:layout_alignParentRight="true"
-		android:paddingTop="15dp"
-		android:paddingRight="11dp">
-		<FrameLayout
-			android:layout_height="wrap_content"
-			android:id="@+id/frmWarning"
-			android:layout_width="wrap_content"
-			android:visibility="invisible">
-			<ImageView
-				android:id="@+id/imgWarning"
-				android:adjustViewBounds="true"
-				android:layout_height="fill_parent"
-				android:src="@drawable/indicator_input_error"
-				android:scaleType="fitXY"
-				android:layout_width="wrap_content"
-				android:layout_gravity="top|right"
-				android:maxWidth="17dp"
-				android:maxHeight="17dp"
-				android:minHeight="17dp"
-				android:minWidth="17dp"></ImageView>
-		</FrameLayout>
-	</RelativeLayout>
-	<RelativeLayout
 		android:layout_width="wrap_content"
 		android:layout_height="wrap_content"
 		android:layout_alignTop="@+id/RelativeLayout02"

--- a/app/src/main/res/layout/widget_transparent.xml
+++ b/app/src/main/res/layout/widget_transparent.xml
@@ -15,7 +15,7 @@
 		android:layout_height="22dp"
 		android:layout_width="fill_parent"
 		android:id="@+id/hitBox"
-		android:focusable="true"></FrameLayout>
+		android:focusable="true"/>
 	<LinearLayout
 		android:layout_height="wrap_content"
 		android:layout_width="wrap_content"
@@ -29,7 +29,7 @@
 			android:layout_gravity="center_vertical"
 			android:baselineAlignBottom="true"
 			android:src="@drawable/ic_launcher"
-			android:scaleType="fitXY"></ImageView>
+			android:scaleType="fitXY"/>
 	<TextView
 		android:id="@+id/txtWidgetAccountname"
 		android:layout_height="wrap_content"
@@ -41,7 +41,7 @@
 		android:layout_marginLeft="2dp"
 		android:layout_marginRight="2dp"
 		android:text="Bankdroid"
-		android:lines="1"></TextView>
+		android:lines="1"/>
 	<TextView
 		android:id="@+id/txtWidgetAccountnameBlur"
 		android:layout_height="wrap_content"
@@ -54,7 +54,7 @@
 		android:layout_marginRight="2dp"
 		android:text="Bankdroid"
 		android:lines="1"
-		android:visibility="gone"></TextView>
+		android:visibility="gone"/>
 	</LinearLayout>
 	<LinearLayout
 		android:id="@+id/layWidgetRow02"
@@ -71,8 +71,9 @@
 			android:scaleType="centerInside"
 			android:adjustViewBounds="false"
 			android:paddingTop="5dp"
-			android:visibility="gone"></ImageView>
+			android:visibility="gone"/>
 		<TextView
+
 			android:textColor="#fff"
 			android:inputType="none"
 			android:layout_gravity="center_vertical|center_horizontal"
@@ -107,26 +108,7 @@
 				android:maxHeight="2dp"
 				android:minHeight="2dp"
 				android:minWidth="17dp"
-				android:visibility="visible"></ProgressBar>
-		</FrameLayout>
-
-
-		<FrameLayout
-			android:layout_height="wrap_content"
-			android:id="@+id/frmWarning"
-			android:layout_width="fill_parent"
-			android:visibility="invisible">
-			<ImageView
-				android:id="@+id/imgWarning"
-				android:adjustViewBounds="true"
-				android:layout_gravity="bottom|right"
-				android:layout_height="fill_parent"
-				android:src="@drawable/indicator_input_error"
-				android:scaleType="fitXY"
-				android:layout_width="wrap_content"></ImageView>
+				android:visibility="visible"/>
 		</FrameLayout>
 	</LinearLayout>
-
-
-
 </RelativeLayout>

--- a/config/quality/lint/lint.xml
+++ b/config/quality/lint/lint.xml
@@ -8,7 +8,6 @@
     <issue id="BatteryLife" severity="ignore" />
     <issue id="ButtonCase" severity="ignore" />
     <issue id="ClickableViewAccessibility" severity="ignore" />
-    <issue id="CommitPrefEdits" severity="ignore" />
     <issue id="ContentDescription" severity="ignore" />
     <issue id="DefaultLocale" severity="ignore" />
     <issue id="Deprecated" severity="ignore" />

--- a/config/quality/pmd/pmd-ruleset.xml
+++ b/config/quality/pmd/pmd-ruleset.xml
@@ -70,7 +70,6 @@
         <exclude name="JUnitTestsShouldIncludeAssert" />
         <exclude name="LawOfDemeter" />
         <exclude name="LocalVariableCouldBeFinal" />
-        <exclude name="LongInstantiation" />
         <exclude name="LongVariable" />
         <exclude name="LooseCoupling" />
         <exclude name="LoosePackageCoupling" />


### PR DESCRIPTION
Part of fixing #610.

On my phone, the account-disabled warning symbol in the widget is a bit outside of the widget and almost invisible.

Strikethrough is fine though, so this change replaces the warning icon in the widget with overstriking the balance if updates have been disabled for the account.

Also, in accordance with the Boy Scout Rule, this change fixes some warnings in `BankdroidWidgetProvider.java` and re-enables one Lint rule and one PMD rule.