### PR TITLE
Fixes Amex crashes

### DIFF
--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/americanexpress/model/AccountActivity.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/americanexpress/model/AccountActivity.java
@@ -2,6 +2,7 @@ package com.liato.bankdroid.banking.banks.americanexpress.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+import java.util.Collections;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -9,7 +10,8 @@ public class AccountActivity {
     List<Transaction> transactionList;
 
     public List<Transaction> getTransactionList() {
-        return transactionList;
+        return transactionList == null ?
+                Collections.<Transaction>emptyList() : transactionList;
     }
 
     public void setTransactionList(List<Transaction> transactionList) {


### PR DESCRIPTION
Make sure that transaction model for amex never return null, but an empty list if no transactions are available.

Fixes #637