### PR TITLE
Fix overlapping layout

### DIFF
--- a/app/src/main/res/layout/transactions.xml
+++ b/app/src/main/res/layout/transactions.xml
@@ -29,7 +29,7 @@
         android:layout_width="fill_parent"
         android:layout_height="fill_parent"
         android:layout_alignParentBottom="true"
-        android:layout_below="@+id/layBankHeader"
+        android:layout_below="@+id/txtTranDesc"
         android:background="@drawable/background_repeat"
         android:cacheColorHint="#00000000"
         android:clickable="false"

--- a/config/quality/pmd/pmd-ruleset.xml
+++ b/config/quality/pmd/pmd-ruleset.xml
@@ -11,6 +11,10 @@
 
     <!-- FIXME: This file should be empty and all violations fixed. Then we will all hug. -->
     <rule ref="rulesets/internal/all-java.xml">
+
+        <!-- This check needs extra configuration to work, disable it for now -->
+        <exclude name="LoosePackageCoupling" />
+
         <exclude name="AbstractNaming" />
         <exclude name="AccessorClassGeneration" />
         <exclude name="AppendCharacterWithChar" />

--- a/tools/update-suppressions.sh
+++ b/tools/update-suppressions.sh
@@ -47,6 +47,10 @@ function set_pmd_suppressions() {
 
     <!-- FIXME: This file should be empty and all violations fixed. Then we will all hug. -->
     <rule ref="rulesets/internal/all-java.xml">
+
+        <!-- This check needs extra configuration to work, disable it for now -->
+        <exclude name="LoosePackageCoupling" />
+
 EOF
 
   for RULE in $1; do


### PR DESCRIPTION
Also, boy-scout-principle update suppressions script to disable a PMD
rule that needs configuration to work that we don't supply right now.