### PR TITLE
Add bank-disabled warning to TransactionsActivity

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,13 @@
 Please view this file on the master branch, on stable branches it's out of date.
 
 Not yet released
+* Warn about disabled banks in the transactions list
 * Remove TrustBuddy since they're no longer in business
 * Remove unused class MobilbankenBase
 
 v1.9.10.10 (2016-10-17)
 * Fixes crash for Amex
-* Strikethrough balance in widget indicates update problems. 
+* Strikethrough balance in widget indicates update problems.
 
 v1.9.10.9 (2016-10-12)
 * Länsförsäkringar: Remove broken web links

--- a/app/src/main/java/com/liato/bankdroid/BankEditActivity.java
+++ b/app/src/main/java/com/liato/bankdroid/BankEditActivity.java
@@ -81,8 +81,6 @@ public class BankEditActivity extends LockableActivity implements OnItemSelected
     @InjectView(R.id.txtErrorDesc)
     TextView mErrorDescription;
 
-    private final static String TAG = "BankEditActivity";
-
     private Bank SELECTED_BANK;
 
     private long BANKID = -1;

--- a/app/src/main/java/com/liato/bankdroid/DataRetrieverTask.java
+++ b/app/src/main/java/com/liato/bankdroid/DataRetrieverTask.java
@@ -45,8 +45,6 @@ import timber.log.Timber;
 
 public class DataRetrieverTask extends AsyncTask<String, String, Void> {
 
-    private final static String TAG = "DataRetrieverTask";
-
     private final ProgressDialog dialog;
 
     private final MainActivity parent;

--- a/app/src/main/java/com/liato/bankdroid/LockableActivity.java
+++ b/app/src/main/java/com/liato/bankdroid/LockableActivity.java
@@ -35,7 +35,6 @@ import android.os.SystemClock;
 import android.preference.PreferenceManager;
 import android.support.v7.app.ActionBarActivity;
 import android.support.v7.widget.Toolbar;
-import android.view.LayoutInflater;
 import android.view.View;
 import android.view.WindowManager;
 
@@ -50,13 +49,6 @@ public class LockableActivity extends ActionBarActivity {
     private LockPatternUtils mLockPatternUtils;
 
     private boolean mHasLoaded = false;
-
-    //    private LinearLayout mTitlebarButtons;
-    private LayoutInflater mInflater;
-//    private ProgressBar mProgressBar;
-
-//    private ImageView mHomeButton;
-//    private View mHomeButtonCont;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/com/liato/bankdroid/SettingsActivity.java
+++ b/app/src/main/java/com/liato/bankdroid/SettingsActivity.java
@@ -42,8 +42,6 @@ import timber.log.Timber;
 public class SettingsActivity extends LockablePreferenceActivity
         implements OnPreferenceClickListener, OnPreferenceChangeListener {
 
-    private final static String TAG = "SettingsActivity";
-
     private final static int DISABLE_LOCKPATTERN = 1;
 
     private final static int ENABLE_LOCKPATTERN = 2;

--- a/app/src/main/java/com/liato/bankdroid/StartupReceiver.java
+++ b/app/src/main/java/com/liato/bankdroid/StartupReceiver.java
@@ -30,8 +30,6 @@ import android.preference.PreferenceManager;
 
 public class StartupReceiver extends BroadcastReceiver {
 
-    private final static String TAG = "StartupReceiver";
-
     public static void setAlarm(Context context) {
         PendingIntent alarmSender;
         alarmSender = PendingIntent

--- a/app/src/main/java/com/liato/bankdroid/TransactionsActivity.java
+++ b/app/src/main/java/com/liato/bankdroid/TransactionsActivity.java
@@ -24,6 +24,7 @@ import com.liato.bankdroid.banking.Transaction;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -37,8 +38,6 @@ import java.util.Collections;
 import java.util.List;
 
 public class TransactionsActivity extends LockableActivity {
-
-    final static String TAG = "TransactionActivity";
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -70,6 +69,10 @@ public class TransactionsActivity extends LockableActivity {
         icon.setImageResource(bank.getImageResource());
         List<Transaction> transactions = account.getTransactions();
 
+        if (bank.isDisabled()) {
+            findViewById(R.id.txtDisabledWarning).setVisibility(View.VISIBLE);
+        }
+
         if (!transactions.isEmpty()) {
             Collections.sort(transactions);
             findViewById(R.id.txtTranDesc).setVisibility(View.GONE);
@@ -93,7 +96,7 @@ public class TransactionsActivity extends LockableActivity {
     private void redirectToMain(String errorMessage) {
         final Intent intent = new Intent(this, MainActivity.class);
         ((BankdroidApplication) getApplicationContext())
-                .setApplicationMessage(getString(R.string.error_bank_not_found));
+                .setApplicationMessage(errorMessage);
         startActivity(intent);
     }
 
@@ -101,7 +104,7 @@ public class TransactionsActivity extends LockableActivity {
 
         private LayoutInflater inflater;
 
-        private ArrayList<Object> items = new ArrayList<Object>();
+        private ArrayList<Object> items = new ArrayList<>();
 
         public TransactionsAdapter(List<Transaction> transactions) {
             inflater = (LayoutInflater) getSystemService(Context.LAYOUT_INFLATER_SERVICE);
@@ -129,10 +132,10 @@ public class TransactionsActivity extends LockableActivity {
             ((TextView) convertView.findViewById(R.id.txtAmount)).setText(
                     Helpers.formatBalance(transaction.getAmount(), transaction.getCurrency()));
             if (transaction.getAmount().signum() == 1) {
-                ((ImageView) convertView.findViewById(R.id.imgColor))
+                convertView.findViewById(R.id.imgColor)
                         .setBackgroundResource(R.drawable.transaction_positive);
             } else {
-                ((ImageView) convertView.findViewById(R.id.imgColor))
+                convertView.findViewById(R.id.imgColor)
                         .setBackgroundResource(R.drawable.transaction_negative);
             }
             return convertView;
@@ -162,6 +165,7 @@ public class TransactionsActivity extends LockableActivity {
         }
 
         @Override
+        @Nullable
         public View getView(int position, View convertView, ViewGroup parent) {
             Object item = getItem(position);
             if (item == null) {

--- a/app/src/main/java/com/liato/bankdroid/WebViewActivity.java
+++ b/app/src/main/java/com/liato/bankdroid/WebViewActivity.java
@@ -47,11 +47,7 @@ import static android.graphics.Color.WHITE;
 
 public class WebViewActivity extends LockableActivity implements OnClickListener {
 
-    private final static String TAG = "WebViewActivity";
-
     private WebView mWebView;
-
-    private final LockableActivity activity = this;
 
     private boolean mFirstPageLoaded = false;
 

--- a/app/src/main/java/com/liato/bankdroid/appwidget/AutoRefreshService.java
+++ b/app/src/main/java/com/liato/bankdroid/appwidget/AutoRefreshService.java
@@ -75,8 +75,6 @@ public class AutoRefreshService extends Service {
     public final static String BROADCAST_TRANSACTIONS_UPDATED
             = "com.liato.bankdroid.action.TRANSACTIONS";
 
-    private final static String TAG = "AutoRefreshService";
-
     public static void showNotification(final Bank bank, final Account account,
             final BigDecimal diff, Context context) {
 
@@ -189,16 +187,16 @@ public class AutoRefreshService extends Service {
     @Override
     public void onStart(Intent intent, int startId) {
         super.onStart(intent, startId);
-        handleStart(intent, startId);
+        handleStart();
     }
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
-        handleStart(intent, startId);
+        handleStart();
         return START_NOT_STICKY;
     }
 
-    private void handleStart(Intent intent, int startId) {
+    private void handleStart() {
         ConnectivityManager cm = (ConnectivityManager) getSystemService(CONNECTIVITY_SERVICE);
         NetworkInfo ni = cm.getActiveNetworkInfo();
         if (ni != null &&

--- a/app/src/main/java/com/liato/bankdroid/appwidget/WidgetConfigureActivity.java
+++ b/app/src/main/java/com/liato/bankdroid/appwidget/WidgetConfigureActivity.java
@@ -40,8 +40,6 @@ public class WidgetConfigureActivity extends LockableActivity {
 
     private static final String WIDGET_PREFIX = "widget_";
 
-    private static final int LOGIN_ID = 1;
-
     int mAppWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID;
 
     private AccountsAdapter adapter;

--- a/app/src/main/java/com/liato/bankdroid/lockpattern/ChooseLockPattern.java
+++ b/app/src/main/java/com/liato/bankdroid/lockpattern/ChooseLockPattern.java
@@ -400,8 +400,8 @@ public class ChooseLockPattern extends Activity implements View.OnClickListener 
      * The states of the left footer button.
      */
     enum LeftButtonMode {
-        Cancel(R.string.lock_cancel, true),
-        CancelDisabled(R.string.lock_cancel, false),
+        Cancel(android.R.string.cancel, true),
+        CancelDisabled(android.R.string.cancel, false),
         Retry(R.string.lockpattern_retry_button_text, true),
         RetryDisabled(R.string.lockpattern_retry_button_text, false),
         Gone(ID_EMPTY_MESSAGE, false);
@@ -429,7 +429,7 @@ public class ChooseLockPattern extends Activity implements View.OnClickListener 
         ContinueDisabled(R.string.lockpattern_continue_button_text, false),
         Confirm(R.string.lockpattern_confirm_button_text, true),
         ConfirmDisabled(R.string.lockpattern_confirm_button_text, false),
-        Ok(R.string.lock_ok, true);
+        Ok(android.R.string.ok, true);
 
         final int text;
 

--- a/app/src/main/java/com/liato/bankdroid/provider/BankTransactionsProvider.java
+++ b/app/src/main/java/com/liato/bankdroid/provider/BankTransactionsProvider.java
@@ -51,9 +51,6 @@ public class BankTransactionsProvider extends ContentProvider implements
 
     private static final String CONTENT_PROVIDER_API_KEY = "content_provider_api_key";
 
-    // Tags can be at most 23 characters, note the slight abbreviation
-    private final static String TAG = "BankTransactionsProvdr";
-
     private final static int TRANSACTIONS = 0;
 
     private final static int BANK_ACCOUNTS = 1;

--- a/app/src/main/res/layout/bank.xml
+++ b/app/src/main/res/layout/bank.xml
@@ -74,7 +74,7 @@
                 android:id="@+id/btnSettingsCancel"
                 style="@style/Menu_Button"
                 android:drawableLeft="@drawable/button_cancel"
-                android:text="@string/cancel"></Button>
+                android:text="@android:string/cancel"></Button>
 
             <ImageView
                 android:layout_width="wrap_content"

--- a/app/src/main/res/layout/pair_applications_layout.xml
+++ b/app/src/main/res/layout/pair_applications_layout.xml
@@ -54,7 +54,7 @@
 			android:layout_width="fill_parent">
 			<Button
 				android:onClick="cancelPairing"
-				android:text="@string/cancel"
+				android:text="@android:string/cancel"
 				android:drawableLeft="@drawable/button_cancel"
 				android:id="@+id/btnSettingsCancel"
 				style="@style/Menu_Button"></Button>

--- a/app/src/main/res/layout/transactions.xml
+++ b/app/src/main/res/layout/transactions.xml
@@ -16,10 +16,21 @@
         android:layout_below="@id/toolbar" />
 
     <TextView
-        android:id="@+id/txtTranDesc"
+        android:id="@+id/txtDisabledWarning"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:layout_below="@+id/layBankHeader"
+        android:layout_margin="10dp"
+        android:drawableLeft="@drawable/indicator_input_error"
+        android:drawablePadding="10dp"
+        android:text="@string/disabled_refresh_or_edit"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/txtTranDesc"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/txtDisabledWarning"
         android:layout_margin="10dp"
         android:text="@string/tran_desc"
         android:visibility="visible" />

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
     <string name="about">Om</string>
     <string name="version">Version $version av</string>
     <string name="widget_name_small">Bankdroid (Liten)</string>
     <string name="widget_name_large">Bankdroid (Stor)</string>
     <string name="accounts_were_not_updated">Saldon för följande konton har ej uppdaterats</string>
-    <string name="updating_account_balance">Uppdaterar saldoinformation...</string>
+    <string name="updating_account_balance">Uppdaterar saldoinformation…</string>
     <string name="errors_when_updating">Fel vid uppdatering</string>
-    <string name="logging_in">Loggar in...</string>
+    <string name="logging_in">Loggar in…</string>
     <string name="could_not_create_account">Kunde ej skapa konto</string>
 	<string name="transparent_background">Transparent bakgrund</string>
     <string name="settings">Inställningar</string>
@@ -20,7 +19,6 @@
     <string name="optional_field">(frivilligt)</string>
     <string name="error_desc">Senaste uppdateringsförsöket misslyckades och uppdateringar för detta konto har inaktiverats. Se till att lösenord och användarnamn är korrekt angivet och tryck på spara-knappen.</string>
 
-    <string name="cancel">AVBRYT</string>
     <string name="save">SPARA</string>
 
 	<string name="add_new_account">LÄGG TILL BANK</string>
@@ -206,8 +204,6 @@
     <string name="lock_example_message">Anslut minst fyra punkter.
     \n\nVälj \u201CNästa\u201D när du vill rita ditt eget grafiska lösenord.
     </string>
-	<string name="lock_cancel">Avbryt</string>
-	<string name="lock_ok">Ok</string>
 
 	<string name="select_a_bank">Välj en bank</string>
 	<string name="invalid_integer">%1$s är inte ett giltigt positivt heltal, var god försök igen.</string>
@@ -222,4 +218,5 @@
     <!-- Error messages -->
     <string name="error_bank_not_found">Den valda banken kunde inte hittas.</string>
     <string name="error_account_not_found">Det valda kontot kunde inte hittas.</string>
+	<string name="disabled_refresh_or_edit">Senaste uppdateringen misslyckades och vi har slutat uppdatera kontot automatiskt. Uppdatera kontot manuellt för att försöka igen eller ändra kontot och kontrollera dina inloggningsuppgifter.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources  xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="version">Version $version by</string>
-    <string name="app_name">Bankdroid</string>
+    <string name="app_name" translatable="false">Bankdroid</string>
     <string name="widget_name_small">Bankdroid (Small)</string>
     <string name="widget_name_large">Bankdroid (Large)</string>
     <string name="about">About</string>
     <string name="accounts_were_not_updated">Balance for the following accounts could not be updated</string>
-    <string name="updating_account_balance">Refreshing account balance...</string>
+    <string name="updating_account_balance">Refreshing account balance…</string>
     <string name="errors_when_updating">Errors while refreshing</string>
-    <string name="logging_in">Signing in...</string>
+    <string name="logging_in">Signing in…</string>
     <string name="could_not_create_account">Could not create account</string>
 	<string name="transparent_background">Transparent background</string>
     <string name="settings">Settings</string>
@@ -21,12 +21,11 @@
     <string name="bank">Bank</string>
     <string name="error_desc">The last update was unsuccessful and updates for this account have been disabled. Make sure you\'ve entered your username and password correctly and press the save button.</string>
 
-    <string name="cancel">CANCEL</string>
     <string name="save">SAVE</string>
 
 	<string name="add_new_account">ADD BANK</string>
 
-	<string name="main_instructions">You have not added any bank accounts yet, press the "Accounts" button in the menu to add a new account.</string>
+	<string name="main_instructions">You have not added any bank accounts yet, press the “Accounts” button in the menu to add a new account.</string>
 	<string name="refresh_balance">REFRESH</string>
 
 	<string name="choose_an_account">Choose an account</string>
@@ -133,6 +132,7 @@
     <string name="menu_hide_hidden">Hide hidden accounts</string>
 
     <string name="tran_desc">No transaction history available for this account.</string>
+	<string name="disabled_refresh_or_edit">The last update was unsuccessful and updates for this account have been disabled. Manually refresh the account to try again or edit the account and check your credentials.</string>
 
     <string name="thanks_to">Thanks to</string>
     <string name="thanks">
@@ -258,8 +258,6 @@
     <string name="lock_example_message">Connect at least four dots.\n
         \nSelect \u201CNext\u201D when you\u2019re ready to draw your own pattern.
     </string>
-	<string name="lock_cancel">Cancel</string>
-	<string name="lock_ok">Ok</string>
 
 	<string name="permission_provider_label">Basic account information and the transaction history</string>
 	<string name="permission_provider_desc">Allows the application to access what banks and accounts are configured in BankDroids. Your Bank credentials are not exposed. Transaction history can also be accessed.</string>

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/Account.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/Account.java
@@ -18,6 +18,8 @@ package com.liato.bankdroid.banking;
 
 import com.liato.bankdroid.provider.IAccountTypes;
 
+import android.support.annotation.Nullable;
+
 import java.math.BigDecimal;
 import java.util.List;
 
@@ -120,6 +122,7 @@ public class Account implements IAccountTypes {
         this.id = id;
     }
 
+    @Nullable
     public Bank getBank() {
         return bank;
     }

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/ica/model/Account.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/ica/model/Account.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Account {
@@ -30,9 +28,7 @@ public class Account {
     private double creditLimit;
 
     @JsonProperty("Transactions")
-    private List<Transaction> transactions = new ArrayList<Transaction>();
-
-    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+    private List<Transaction> transactions = new ArrayList<>();
 
     @JsonProperty("Name")
     public String getName() {

--- a/bankdroid-legacy/src/main/java/eu/nullbyte/android/urllib/CertPinningSSLSocketFactory.java
+++ b/bankdroid-legacy/src/main/java/eu/nullbyte/android/urllib/CertPinningSSLSocketFactory.java
@@ -48,8 +48,6 @@ import javax.net.ssl.TrustManager;
 
 public class CertPinningSSLSocketFactory extends SSLSocketFactory {
 
-    private final static String TAG = CertPinningSSLSocketFactory.class.getSimpleName();
-
     private SSLContext sslcontext = null;
 
     private Certificate[] certificates;

--- a/config/quality/lint/lint.xml
+++ b/config/quality/lint/lint.xml
@@ -6,7 +6,6 @@
     <issue id="AlwaysShowAction" severity="ignore" />
     <issue id="AppCompatResource" severity="ignore" />
     <issue id="BatteryLife" severity="ignore" />
-    <issue id="ButtonCase" severity="ignore" />
     <issue id="ClickableViewAccessibility" severity="ignore" />
     <issue id="ContentDescription" severity="ignore" />
     <issue id="DefaultLocale" severity="ignore" />
@@ -19,6 +18,7 @@
     <issue id="HardcodedText" severity="ignore" />
     <issue id="IconDensities" severity="ignore" />
     <issue id="IconDuplicates" severity="ignore" />
+    <issue id="IconExpectedSize" severity="ignore" />
     <issue id="IconLocation" severity="ignore" />
     <issue id="IconMissingDensityFolder" severity="ignore" />
     <issue id="InefficientWeight" severity="ignore" />
@@ -28,6 +28,7 @@
     <issue id="MergeRootFrame" severity="ignore" />
     <issue id="MissingTranslation" severity="ignore" />
     <issue id="NewApi" severity="ignore" />
+    <issue id="NewerVersionAvailable" severity="ignore" />
     <issue id="NotSibling" severity="ignore" />
     <issue id="ObsoleteLayoutParam" severity="ignore" />
     <issue id="Orientation" severity="ignore" />
@@ -38,14 +39,14 @@
     <issue id="RtlHardcoded" severity="ignore" />
     <issue id="RtlSymmetry" severity="ignore" />
     <issue id="ScrollViewSize" severity="ignore" />
+    <issue id="SelectableText" severity="ignore" />
     <issue id="SetJavaScriptEnabled" severity="ignore" />
     <issue id="SimpleDateFormat" severity="ignore" />
     <issue id="SpUsage" severity="ignore" />
     <issue id="TrulyRandom" severity="ignore" />
-    <issue id="TypographyEllipsis" severity="ignore" />
-    <issue id="Typos" severity="ignore" />
     <issue id="UnknownIdInLayout" severity="ignore" />
     <issue id="UnusedAttribute" severity="ignore" />
+    <issue id="UnusedIds" severity="ignore" />
     <issue id="UnusedResources" severity="ignore" />
     <issue id="UseCompoundDrawables" severity="ignore" />
     <issue id="UselessParent" severity="ignore" />

--- a/config/quality/pmd/pmd-ruleset.xml
+++ b/config/quality/pmd/pmd-ruleset.xml
@@ -108,9 +108,7 @@
         <exclude name="UnnecessaryParentheses" />
         <exclude name="UnnecessaryWrapperObjectCreation" />
         <exclude name="UnsynchronizedStaticDateFormatter" />
-        <exclude name="UnusedFormalParameter" />
         <exclude name="UnusedLocalVariable" />
-        <exclude name="UnusedPrivateField" />
         <exclude name="UnusedPrivateMethod" />
         <exclude name="UseCollectionIsEmpty" />
         <exclude name="UseConcurrentHashMap" />

--- a/config/quality/quality.gradle
+++ b/config/quality/quality.gradle
@@ -71,6 +71,7 @@ if(plugins.hasPlugin('android') || plugins.hasPlugin('com.android.library')) {
         lintOptions {
             abortOnError true
             warningsAsErrors true
+            checkAllWarnings true
 
             // FIXME: This file contains *far* too many disabled checks. Somebody think of the children!
             lintConfig file("${project.rootDir}/config/quality/lint/lint.xml")


### PR DESCRIPTION
If a bank is disabled, and you click on the widget, with this change in
place you now get a warning about the bank being disabled and what you
can do about it.

This is part of fixing #610.

To be able to work on this I first fixed all warnings in the two files
I had to change. To remove the suppressions for those warnings so that
they don't come back, I fixed all other instances of those problems as
well.

Note that this change also enables *all* Android Lint warnings (rather than just the on-by-default ones) before we disable those that we violate. That made some additional suppressions show up in `lint.xml`.