### PR TITLE
Fake Urllib exception stack traces

### DIFF
--- a/bankdroid-legacy/build.gradle
+++ b/bankdroid-legacy/build.gradle
@@ -39,4 +39,7 @@ dependencies {
         exclude module: 'stax-api'
         exclude module: 'xpp3'
     }
+
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-core:1.10.19'
 }

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/utils/ExceptionUtils.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/utils/ExceptionUtils.java
@@ -1,0 +1,67 @@
+package com.liato.bankdroid.utils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+
+import timber.log.Timber;
+
+public class ExceptionUtils {
+    private static final String PREFIX = "com.liato.bankdroid.";
+
+    /**
+     * Take an exception thrown and make it look like it came from Bankdroid.
+     * <p/>
+     * Specifically, if Urllib.java, called by Bankdroid code, throws an exception,
+     * rewrite the exception so that it appears as if it was thrown from the
+     * Bankdroid method calling Urllib, but caused by the original Exception.
+     */
+    public static <T extends Throwable> T bankdroidifyException(T exception) {
+        StackTraceElement[] bankdroidifiedStacktrace =
+                bankdroidifyStacktrace(exception.getStackTrace());
+        if (bankdroidifiedStacktrace.length == exception.getStackTrace().length) {
+            // Unable to bankdroidify stacktrace, never mind
+            return exception;
+        }
+
+        T returnMe;
+        try {
+            returnMe = (T)exception.getClass().getConstructor(String.class)
+                    .newInstance(exception.getMessage());
+        } catch (InstantiationException e) {
+            Timber.e(e, "Unable to Bankdroidify exception of type %s", exception.getClass());
+            return exception;
+        } catch (InvocationTargetException e) {
+            Timber.e(e, "Unable to Bankdroidify exception of type %s", exception.getClass());
+            return exception;
+        } catch (IllegalAccessException e) {
+            Timber.e(e, "Unable to Bankdroidify exception of type %s", exception.getClass());
+            return exception;
+        } catch (NoSuchMethodException e) {
+            Timber.e(e, "Unable to Bankdroidify exception of type %s", exception.getClass());
+            return exception;
+        }
+
+        returnMe.initCause(exception);
+
+        returnMe.setStackTrace(bankdroidifiedStacktrace);
+
+        return returnMe;
+    }
+
+    /**
+     * Remove all initial non-Bankdroid frames from a stack.
+     *
+     * @return A copy of rawStack but with the initial non-Bankdroid frames removed
+     */
+    private static StackTraceElement[] bankdroidifyStacktrace(final StackTraceElement[] rawStack) {
+        for (int i = 0; i < rawStack.length; i++) {
+            StackTraceElement stackTraceElement = rawStack[i];
+            if (stackTraceElement.getClassName().startsWith(PREFIX)) {
+                return Arrays.copyOfRange(rawStack, i, rawStack.length);
+            }
+        }
+
+        // No Bankdroid stack frames found, never mind
+        return rawStack;
+    }
+}

--- a/bankdroid-legacy/src/main/java/eu/nullbyte/android/urllib/Urllib.java
+++ b/bankdroid-legacy/src/main/java/eu/nullbyte/android/urllib/Urllib.java
@@ -17,6 +17,7 @@
 package eu.nullbyte.android.urllib;
 
 import com.liato.bankdroid.legacy.R;
+import com.liato.bankdroid.utils.ExceptionUtils;
 
 import org.apache.http.ConnectionReuseStrategy;
 import org.apache.http.HttpEntity;
@@ -146,7 +147,11 @@ public class Urllib {
     }
 
     public String open(String url) throws ClientProtocolException, IOException {
-        return this.open(url, new ArrayList<NameValuePair>());
+        try {
+            return this.open(url, new ArrayList<NameValuePair>());
+        } catch (IOException e) {
+            throw ExceptionUtils.bankdroidifyException(e);
+        }
     }
 
     public String post(String url) throws ClientProtocolException, IOException {
@@ -155,7 +160,11 @@ public class Urllib {
 
     public String open(String url, List<NameValuePair> postData)
             throws ClientProtocolException, IOException {
-        return open(url, postData, false);
+        try {
+            return open(url, postData, false);
+        } catch (IOException e) {
+            throw ExceptionUtils.bankdroidifyException(e);
+        }
     }
 
     public String open(String url, List<NameValuePair> postData, boolean forcePost)
@@ -171,7 +180,11 @@ public class Urllib {
             boolean forcePost) throws ClientProtocolException, IOException {
         HttpEntity entity = (postData == null || postData.isEmpty()) && !forcePost ? null
                 : new UrlEncodedFormEntity(postData, this.charset);
-        return openAsHttpResponse(url, entity, forcePost);
+        try {
+            return openAsHttpResponse(url, entity, forcePost);
+        } catch (IOException e) {
+            throw ExceptionUtils.bankdroidifyException(e);
+        }
     }
 
     public HttpResponse openAsHttpResponse(String url, boolean forcePost)
@@ -181,10 +194,14 @@ public class Urllib {
 
     public HttpResponse openAsHttpResponse(String url, HttpEntity entity, boolean forcePost)
             throws ClientProtocolException, IOException {
-        if ((entity == null) && !forcePost) {
-            return openAsHttpResponse(url, entity, HttpMethod.GET);
-        } else {
-            return openAsHttpResponse(url, entity, HttpMethod.POST);
+        try {
+            if ((entity == null) && !forcePost) {
+                return openAsHttpResponse(url, entity, HttpMethod.GET);
+            } else {
+                return openAsHttpResponse(url, entity, HttpMethod.POST);
+            }
+        } catch (IOException e) {
+            throw ExceptionUtils.bankdroidifyException(e);
         }
     }
 
@@ -273,8 +290,12 @@ public class Urllib {
 
     public InputStream openStream(String url, String postData, boolean forcePost)
             throws ClientProtocolException, IOException {
-        return openStream(url, postData != null ? new StringEntity(postData, this.charset) : null,
-                forcePost);
+        try {
+            return openStream(url, postData != null ? new StringEntity(postData, this.charset) : null,
+                    forcePost);
+        } catch (IOException e) {
+            throw ExceptionUtils.bankdroidifyException(e);
+        }
     }
 
     public InputStream openStream(String url, HttpEntity postData, boolean forcePost)

--- a/bankdroid-legacy/src/test/java/com/liato/bankdroid/utils/ExceptionUtilsTest.java
+++ b/bankdroid-legacy/src/test/java/com/liato/bankdroid/utils/ExceptionUtilsTest.java
@@ -1,0 +1,41 @@
+package com.liato.bankdroid.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import eu.nullbyte.android.urllib.Urllib;
+
+public class ExceptionUtilsTest {
+    @Test
+    @SuppressWarnings("PMD") // This is for the stack trace printing, we really want to do it here
+    public void bankdroidifyException() throws Exception {
+        Exception raw = null;
+        try {
+            new Urllib(null);
+            Assert.fail("Exception expected");
+        } catch (NullPointerException e) {
+            raw = e;
+        }
+
+        // Print stack traces, useful if the tests fail
+        System.err.println("Before:");
+        raw.printStackTrace();
+
+        System.err.println();
+        System.err.println("After:");
+        Exception bankdroidified = ExceptionUtils.bankdroidifyException(raw);
+        bankdroidified.printStackTrace();
+
+        Assert.assertFalse("Test setup: Top frame of initial exception shouldn't be in Bankdroid",
+                raw.getStackTrace()[0].getClassName().startsWith("com.liato.bankdroid."));
+
+        Assert.assertTrue("Top frame of bankdroidified exception should be in Bankdroid",
+                bankdroidified.getStackTrace()[0].getClassName().startsWith("com.liato.bankdroid."));
+
+        // Verify that e is the cause of bankdroidified
+        Assert.assertSame(raw, bankdroidified.getCause());
+
+        // Verify that re-bankdroidifying is a no-op
+        Assert.assertSame(bankdroidified, ExceptionUtils.bankdroidifyException(bankdroidified));
+    }
+}


### PR DESCRIPTION
In Crashlytics we have a lot of stack traces originating in Urllib.

With this change in place, those exceptions will appear to be
originating from whatever bank tried to call Urllib, and it will be
much more obvious in Crashlytics which banks actually have the most
problems.