### PR TITLE
Östgötatrafiken: Adapt to new login page

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 Not yet released
 * Bioklubben: Use https. It's secure and http page no longer exists.
+* Östgötatrafiken: Adapt to new login page (Facebook login not supported)
 
 v1.9.11 (2016-10-26)
 * Warn about disabled banks in the transactions list

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Ostgotatrafiken.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Ostgotatrafiken.java
@@ -45,9 +45,6 @@ public class Ostgotatrafiken extends Bank {
 
     private static final String NAME_SHORT = "ogt";
 
-    private static final String URL
-            = "https://www.ostgotatrafiken.se/Priser--biljetter/Mina-sidor/Login/";
-
     private static final int BANKTYPE_ID = IBankTypes.OSTGOTATRAFIKEN;
 
     private Pattern reViewState = Pattern.compile(
@@ -75,7 +72,6 @@ public class Ostgotatrafiken extends Bank {
         super.NAME = NAME;
         super.NAME_SHORT = NAME_SHORT;
         super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
     }
 
     public Ostgotatrafiken(String username, String password, Context context) throws BankException,
@@ -90,18 +86,20 @@ public class Ostgotatrafiken extends Bank {
                 R.raw.cert_ostgotatrafiken_login, R.raw.cert_ostgotatrafiken_overview));
 
         List<NameValuePair> postData = new ArrayList<NameValuePair>();
-        postData.add(new BasicNameValuePair("Username", getUsername()));
-        postData.add(new BasicNameValuePair("Password", getPassword()));
-        postData.add(new BasicNameValuePair("Login", "Logga in"));
+        postData.add(new BasicNameValuePair("", "{\"authSource\":10," +
+                                            "\"keepMeLimitedLoggedIn\":true," +
+                                            "\"userName\":\"" + getUsername() + "\"," +
+                                            "\"password\":\"" + getPassword() + "\"," +
+                                            "\"impersonateUserName\":\"\"}"));
 
-        return new LoginPackage(urlopen, postData, response, URL);
+        return new LoginPackage(urlopen, postData, response, "https://www.ostgotatrafiken.se/ajax/Login/Attempt");
     }
 
     @Override
     public Urllib login() throws LoginException, BankException, IOException {
         LoginPackage lp = preLogin();
         response = urlopen.open(lp.getLoginTarget(), lp.getPostData());
-        if (!response.contains("Logga ut")) {
+        if (!response.contains("presentationUserName")) {
             throw new LoginException(res.getText(R.string.invalid_username_password).toString());
         }
         return urlopen;


### PR DESCRIPTION
Östgötatrafiken now supports three ways to log in/authenticate:
- An e-mail address
- A username (for legacy users (such as me))
- Facebook login

Bankdroid only supports e-mail/username login.

(I haven't tested e-mail login, but I expect it to work the same way
as for username logins)
---

You may want to add Östgötatrafiken to the list of supported "banks" on the play store.
