### PR TITLE
Ensure on-disk passwords are unencrypted

### DIFF
--- a/app/src/main/java/com/liato/bankdroid/db/DBAdapter.java
+++ b/app/src/main/java/com/liato/bankdroid/db/DBAdapter.java
@@ -18,23 +18,19 @@ package com.liato.bankdroid.db;
 
 import com.liato.bankdroid.banking.Account;
 import com.liato.bankdroid.banking.Bank;
-import com.liato.bankdroid.banking.LegacyProviderConfiguration;
 import com.liato.bankdroid.banking.Transaction;
-
-import net.sf.andhsli.hotspotlogin.SimpleCrypto;
 
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
+import android.support.annotation.Nullable;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
-
-import timber.log.Timber;
 
 
 public class DBAdapter {
@@ -169,13 +165,6 @@ public class DBAdapter {
             for(Map.Entry<String,String> property : properties.entrySet()) {
                 String value = property.getValue();
                 if(value != null && !value.isEmpty()) {
-                    if (LegacyProviderConfiguration.PASSWORD.equals(property.getKey())) {
-                        try {
-                            value = SimpleCrypto.encrypt(Crypto.getKey(), bank.getPassword());
-                        } catch (Exception e) {
-                            Timber.e(e, "Could not encrypt password.");
-                        }
-                    }
                     ContentValues propertyValues = new ContentValues();
                     propertyValues.put(Database.PROPERTY_KEY, property.getKey());
                     propertyValues.put(Database.PROPERTY_VALUE, value);
@@ -227,6 +216,7 @@ public class DBAdapter {
         mDb.update("banks", initialValues, "_id=" + bankId, null);
     }
 
+    @Nullable
     public Cursor getBank(String bankId) {
         Cursor c = mDb.query("banks",
                 new String[]{"_id", "balance", "banktype", "disabled",
@@ -238,10 +228,12 @@ public class DBAdapter {
         return c;
     }
 
+    @Nullable
     public Cursor getBank(long bankId) {
         return getBank(Long.toString(bankId));
     }
 
+    @Nullable
     public Cursor getAccount(String id) {
         Cursor c = mDb.query("accounts",
                 new String[]{"id", "balance", "name", "bankid", "acctype", "hidden", "notify",

--- a/app/src/main/java/com/liato/bankdroid/db/Database.java
+++ b/app/src/main/java/com/liato/bankdroid/db/Database.java
@@ -6,7 +6,7 @@ public class Database {
 
     static final int DATABASE_VERSION = 12;
 
-    static final String PROPERTY_TABLE_NAME = "connection_properties";
+    public static final String PROPERTY_TABLE_NAME = "connection_properties";
     public static final String PROPERTY_CONNECTION_ID = "connection_id";
     public static final String PROPERTY_KEY = "property";
     public static final String PROPERTY_VALUE = "value";

--- a/app/src/main/java/com/liato/bankdroid/utils/LoggingUtils.java
+++ b/app/src/main/java/com/liato/bankdroid/utils/LoggingUtils.java
@@ -1,11 +1,13 @@
 package com.liato.bankdroid.utils;
 
+import com.crashlytics.android.Crashlytics;
+import com.crashlytics.android.answers.Answers;
+import com.crashlytics.android.answers.CustomEvent;
+import com.liato.bankdroid.BuildConfig;
+
 import android.content.Context;
 import android.text.TextUtils;
 import android.util.Log;
-
-import com.crashlytics.android.Crashlytics;
-import com.liato.bankdroid.BuildConfig;
 
 import io.fabric.sdk.android.Fabric;
 import timber.log.Timber;
@@ -35,6 +37,13 @@ public class LoggingUtils {
     private static boolean isCrashlyticsEnabled() {
         return EmulatorUtils.RUNNING_ON_ANDROID &&
                 !EmulatorUtils.RUNNING_ON_EMULATOR;
+    }
+
+    public static void logCustom(CustomEvent event) {
+        if (isCrashlyticsEnabled()) {
+            event.putCustomAttribute("App Version", BuildConfig.VERSION_NAME);
+            Answers.getInstance().logCustom(event);
+        }
     }
 
     private static class CrashlyticsTree extends Timber.Tree {

--- a/app/src/main/java/net/sf/andhsli/hotspotlogin/SimpleCrypto.java
+++ b/app/src/main/java/net/sf/andhsli/hotspotlogin/SimpleCrypto.java
@@ -22,18 +22,14 @@ import javax.crypto.spec.SecretKeySpec;
  * String cleartext = SimpleCrypto.decrypt(masterpassword, crypto)
  * </pre>
  *
+ * @deprecated <a href="http://android-developers.blogspot.se/2016/06/security-crypto-provider-deprecated-in.html">Broken
+ * on Android Nougat</a>,
+ * <a href="https://android.googlesource.com/platform/tools/base/+/2d252fc75960a3eaf7297c7a7713baf0c60b6aed/lint/libs/lint-checks/src/main/java/com/android/tools/lint/checks/CipherGetInstanceDetector.java#44">considered
+ * broken by Android Lint even before then</a>.
+ *
  * @author ferenc.hechler
  */
 public class SimpleCrypto {
-
-    private final static String HEX = "0123456789ABCDEF";
-
-    public static String encrypt(String seed, String cleartext) throws Exception {
-        byte[] rawKey = getRawKey(StringUtils.getBytes(seed));
-        byte[] result = encrypt(rawKey, StringUtils.getBytes(cleartext));
-        return toHex(result);
-    }
-
     public static String decrypt(String seed, String encrypted) throws Exception {
         byte[] rawKey = getRawKey(StringUtils.getBytes(seed));
         byte[] enc = toByte(encrypted);
@@ -56,14 +52,6 @@ public class SimpleCrypto {
         return raw;
     }
 
-    private static byte[] encrypt(byte[] raw, byte[] clear) throws Exception {
-        SecretKeySpec skeySpec = new SecretKeySpec(raw, "AES");
-        Cipher cipher = Cipher.getInstance("AES");
-        cipher.init(Cipher.ENCRYPT_MODE, skeySpec);
-        byte[] encrypted = cipher.doFinal(clear);
-        return encrypted;
-    }
-
     private static byte[] decrypt(byte[] raw, byte[] encrypted) throws Exception {
         SecretKeySpec skeySpec = new SecretKeySpec(raw, "AES");
         Cipher cipher = Cipher.getInstance("AES");
@@ -72,27 +60,12 @@ public class SimpleCrypto {
         return decrypted;
     }
 
-    public static byte[] toByte(String hexString) {
+    private static byte[] toByte(String hexString) {
         int len = hexString.length() / 2;
         byte[] result = new byte[len];
         for (int i = 0; i < len; i++) {
             result[i] = Integer.valueOf(hexString.substring(2 * i, 2 * i + 2), 16).byteValue();
         }
         return result;
-    }
-
-    public static String toHex(byte[] buf) {
-        if (buf == null) {
-            return "";
-        }
-        StringBuffer result = new StringBuffer(2 * buf.length);
-        for (int i = 0; i < buf.length; i++) {
-            appendHex(result, buf[i]);
-        }
-        return result.toString();
-    }
-
-    private static void appendHex(StringBuffer sb, byte b) {
-        sb.append(HEX.charAt((b >> 4) & 0x0f)).append(HEX.charAt(b & 0x0f));
     }
 }

--- a/config/quality/lint/lint.xml
+++ b/config/quality/lint/lint.xml
@@ -30,6 +30,7 @@
     <issue id="NewerVersionAvailable" severity="ignore" />
     <issue id="NotSibling" severity="ignore" />
     <issue id="ObsoleteLayoutParam" severity="ignore" />
+    <issue id="OldTargetApi" severity="ignore" />
     <issue id="Orientation" severity="ignore" />
     <issue id="Overdraw" severity="ignore" />
     <issue id="ParcelClassLoader" severity="ignore" />


### PR DESCRIPTION
This is a step towards removing password encryption alltogether.

The background is that password encryption is broken on Android Nougat anyway, and that it
didn't provide any extra security before that either.

Since Bankdroid needs to send plain text passwords to the banks, it must
be possible to retrieve the plain text passwords automatically. And if
the passwords are encrypted on disk, Bankdroid needs to have the key.
And if Bankdroid stores both the key and the encrypted password on the
phone, a determined attacker could get both anyway, and the encryption
is useless.

The only thing the encryption has protected against is a user rooting
their own device and retrieving their own plain text passwords. This
would enable the attacker to read their own account balance from the
bank.

Which they likely already could even before this change...

This change also disables an Android Lint check whose outcome changes
over time; these checks are impossible to maintain. And we fixed some
warnings.
