### PR TITLE
Log bank usage statistics to Crashlytics

### DIFF
--- a/app/src/main/java/com/liato/bankdroid/DataRetrieverTask.java
+++ b/app/src/main/java/com/liato/bankdroid/DataRetrieverTask.java
@@ -24,6 +24,7 @@ import com.liato.bankdroid.banking.exceptions.BankChoiceException;
 import com.liato.bankdroid.banking.exceptions.BankException;
 import com.liato.bankdroid.banking.exceptions.LoginException;
 import com.liato.bankdroid.db.DBAdapter;
+import com.liato.bankdroid.utils.LoggingUtils;
 import com.liato.bankdroid.utils.NetworkUtils;
 
 import android.app.AlertDialog;
@@ -80,6 +81,7 @@ public class DataRetrieverTask extends AsyncTask<String, String, Void> {
         return this.dialog;
     }
 
+    @Nullable
     protected Bank getBankFromDb(long bankId, Context parent) {
         return BankFactory.bankFromDb(bankId, parent, true);
     }
@@ -122,6 +124,7 @@ public class DataRetrieverTask extends AsyncTask<String, String, Void> {
             publishProgress(i, bank);
 
             if (isListingAllBanks() && bank.isDisabled()) {
+                LoggingUtils.logDisabledBank(bank);
                 continue;
             }
 
@@ -131,6 +134,8 @@ public class DataRetrieverTask extends AsyncTask<String, String, Void> {
                 bank.closeConnection();
                 saveBank(bank, parent);
                 i++;
+
+                LoggingUtils.logBankUpdate(bank, true);
             } catch (final BankException e) {
                 this.errors.add(bank.getName() + " (" + bank.getUsername()
                         + ")");
@@ -194,6 +199,7 @@ public class DataRetrieverTask extends AsyncTask<String, String, Void> {
                     .setIcon(android.R.drawable.ic_dialog_alert)
                     .setNeutralButton("Ok",
                             new DialogInterface.OnClickListener() {
+                                @Override
                                 public void onClick(
                                         final DialogInterface dialog,
                                         final int id) {

--- a/app/src/main/java/com/liato/bankdroid/utils/LoggingUtils.java
+++ b/app/src/main/java/com/liato/bankdroid/utils/LoggingUtils.java
@@ -4,6 +4,8 @@ import com.crashlytics.android.Crashlytics;
 import com.crashlytics.android.answers.Answers;
 import com.crashlytics.android.answers.CustomEvent;
 import com.liato.bankdroid.BuildConfig;
+import com.liato.bankdroid.banking.Account;
+import com.liato.bankdroid.banking.Bank;
 
 import android.content.Context;
 import android.text.TextUtils;
@@ -40,9 +42,41 @@ public class LoggingUtils {
     }
 
     public static void logCustom(CustomEvent event) {
-        if (isCrashlyticsEnabled()) {
-            event.putCustomAttribute("App Version", BuildConfig.VERSION_NAME);
-            Answers.getInstance().logCustom(event);
+        if (!isCrashlyticsEnabled()) {
+            return;
+        }
+
+        event.putCustomAttribute("App Version", BuildConfig.VERSION_NAME);
+        Answers.getInstance().logCustom(event);
+    }
+
+    public static void logDisabledBank(Bank bank) {
+        if (!isCrashlyticsEnabled()) {
+            return;
+        }
+
+        logCustom(new CustomEvent("Disabled Bank").
+                putCustomAttribute("Name", bank.getDisplayName()));
+    }
+
+    public static void logBankUpdate(Bank bank, boolean withTransactions) {
+        if (!isCrashlyticsEnabled()) {
+            return;
+        }
+
+        logCustom(new CustomEvent("Bank Updated").
+                putCustomAttribute("Name", bank.getDisplayName()).
+                putCustomAttribute("With Transactions", Boolean.toString(withTransactions)));
+
+        boolean hasTransactions = false;
+        for (Account account : bank.getAccounts()) {
+            if (account.getTransactions() != null && !account.getTransactions().isEmpty()) {
+                hasTransactions = true;
+            }
+        }
+        if (withTransactions && !hasTransactions) {
+            logCustom(new CustomEvent("Bank Without Transactions").
+                    putCustomAttribute("Name", bank.getDisplayName()));
         }
     }
 


### PR DESCRIPTION
With this change in place we'll be able to see in Crashlytics:
* which banks are most frequently disabled
* which banks are most frequently used
* for which banks transactions updating doesn't work