### PR TITLE
If asked for an unknown bank, log the id

### DIFF
--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/LegacyBankFactory.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/LegacyBankFactory.java
@@ -144,7 +144,7 @@ public class LegacyBankFactory {
             case IBankTypes.HORS:
                 return new Hors(context);
             default:
-                throw new BankException("BankType id not found.");
+                throw new BankException("BankType id not found: " + id);
         }
     }
 


### PR DESCRIPTION
So instead of getting in Crashlytics...
BankType id not found.
... we now get...
BankType id not found: 1234

This way it will be easier to understand why we get these exceptions and
how they should be handled (or not).