### PR TITLE
PMD: Enforce variable naming

### DIFF
--- a/app/src/main/java/com/liato/bankdroid/BankEditActivity.java
+++ b/app/src/main/java/com/liato/bankdroid/BankEditActivity.java
@@ -81,9 +81,9 @@ public class BankEditActivity extends LockableActivity implements OnItemSelected
     @InjectView(R.id.txtErrorDesc)
     TextView mErrorDescription;
 
-    private Bank SELECTED_BANK;
+    private Bank selectedBank;
 
-    private long BANKID = -1;
+    private long bankId = -1;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -101,16 +101,16 @@ public class BankEditActivity extends LockableActivity implements OnItemSelected
 
         Bundle extras = getIntent().getExtras();
         if (extras != null) {
-            BANKID = extras.getLong("id", -1);
-            if (BANKID != -1) {
-                Bank bank = BankFactory.bankFromDb(BANKID, this, false);
+            bankId = extras.getLong("id", -1);
+            if (bankId != -1) {
+                Bank bank = BankFactory.bankFromDb(bankId, this, false);
                 if (bank != null) {
                     mErrorDescription.setVisibility(
                             bank.isDisabled() ? View.VISIBLE : View.INVISIBLE);
                     mBankSpinner.setEnabled(false);
                     mBankSpinner.setSelection(adapter.getPosition(bank));
-                    SELECTED_BANK = bank;
-                    createForm(SELECTED_BANK.getConnectionConfiguration(),
+                    selectedBank = bank;
+                    createForm(selectedBank.getConnectionConfiguration(),
                             DefaultConnectionConfiguration.fields()
                     );
                     populateForm(bank);
@@ -125,10 +125,10 @@ public class BankEditActivity extends LockableActivity implements OnItemSelected
         if (!validate()) {
             return;
         }
-        SELECTED_BANK.setProperties(getFormParameters(SELECTED_BANK.getConnectionConfiguration()));
-        SELECTED_BANK.setCustomName(getFormParameter(DefaultConnectionConfiguration.NAME));
-        SELECTED_BANK.setDbid(BANKID);
-        new DataRetrieverTask(this, SELECTED_BANK).execute();
+        selectedBank.setProperties(getFormParameters(selectedBank.getConnectionConfiguration()));
+        selectedBank.setCustomName(getFormParameter(DefaultConnectionConfiguration.NAME));
+        selectedBank.setDbid(bankId);
+        new DataRetrieverTask(this, selectedBank).execute();
     }
 
     @OnClick(R.id.btnSettingsCancel)
@@ -139,10 +139,10 @@ public class BankEditActivity extends LockableActivity implements OnItemSelected
     @Override
     public void onItemSelected(AdapterView<?> parentView, View selectedItemView, int pos, long id) {
         Bank selectedBank = (Bank) parentView.getItemAtPosition(pos);
-        if (SELECTED_BANK == null || !SELECTED_BANK.equals(selectedBank)) {
-            SELECTED_BANK = selectedBank;
+        if (this.selectedBank == null || !this.selectedBank.equals(selectedBank)) {
+            this.selectedBank = selectedBank;
                     mFormContainer.removeAllViewsInLayout();
-            createForm(SELECTED_BANK.getConnectionConfiguration(),
+            createForm(this.selectedBank.getConnectionConfiguration(),
                     DefaultConnectionConfiguration.fields()
             );
         }
@@ -233,7 +233,7 @@ public class BankEditActivity extends LockableActivity implements OnItemSelected
 
     private boolean validate() {
         boolean valid = true;
-        Iterator<Field> fields = Iterators.concat(SELECTED_BANK.getConnectionConfiguration().iterator(),
+        Iterator<Field> fields = Iterators.concat(selectedBank.getConnectionConfiguration().iterator(),
                 DefaultConnectionConfiguration.fields().iterator());
         while (fields.hasNext()) {
             Field field = fields.next();
@@ -357,8 +357,8 @@ public class BankEditActivity extends LockableActivity implements OnItemSelected
                     builder.setTitle(R.string.select_a_bank);
                     builder.setItems(items, new DialogInterface.OnClickListener() {
                         public void onClick(DialogInterface dialog, int item) {
-                            SELECTED_BANK.setExtras(e.getBanks().get(item).getId());
-                            new DataRetrieverTask(context, SELECTED_BANK).execute();
+                            selectedBank.setExtras(e.getBanks().get(item).getId());
+                            new DataRetrieverTask(context, selectedBank).execute();
                         }
                     });
                 } else {

--- a/app/src/main/java/com/liato/bankdroid/LockableActivity.java
+++ b/app/src/main/java/com/liato/bankdroid/LockableActivity.java
@@ -40,7 +40,7 @@ import android.view.WindowManager;
 
 public class LockableActivity extends ActionBarActivity {
 
-    private static int PATTERNLOCK_UNLOCK = 42;
+    private static final int PATTERNLOCK_UNLOCK = 42;
 
     protected boolean mSkipLockOnce = false;
 

--- a/app/src/main/java/com/liato/bankdroid/LockablePreferenceActivity.java
+++ b/app/src/main/java/com/liato/bankdroid/LockablePreferenceActivity.java
@@ -31,7 +31,7 @@ import android.view.WindowManager;
 
 public class LockablePreferenceActivity extends PreferenceActivity {
 
-    private static int PATTERNLOCK_UNLOCK = 42;
+    private static final int PATTERNLOCK_UNLOCK = 42;
 
     private SharedPreferences mPrefs;
 

--- a/app/src/main/java/com/liato/bankdroid/MainActivity.java
+++ b/app/src/main/java/com/liato/bankdroid/MainActivity.java
@@ -59,9 +59,9 @@ public class MainActivity extends LockableActivity {
 
     protected static boolean showHidden = false;
 
-    private static Bank selected_bank = null;
+    private static Bank selectedBank = null;
 
-    private static Account selected_account = null;
+    private static Account selectedAccount = null;
 
     private final BroadcastReceiver receiver = new BroadcastReceiver() {
         @Override
@@ -91,14 +91,14 @@ public class MainActivity extends LockableActivity {
             public boolean onItemLongClick(final AdapterView<?> parent, final View view,
                     final int position, final long id) {
                 if (adapter.getItem(position) instanceof Account) {
-                    selected_account = (Account) adapter.getItem(position);
+                    selectedAccount = (Account) adapter.getItem(position);
                     final PopupMenuAccount pmenu = new PopupMenuAccount(parent, view, MainActivity.this);
                     pmenu.showLikeQuickAction(0, 12);
                     return true;
                 } else if (adapter.getItem(position) instanceof Bank) {
-                    selected_bank = (Bank) adapter.getItem(position);
-                    selected_bank.toggleHideAccounts();
-                    DBAdapter.save(selected_bank, MainActivity.this);
+                    selectedBank = (Bank) adapter.getItem(position);
+                    selectedBank.toggleHideAccounts();
+                    DBAdapter.save(selectedBank, MainActivity.this);
                     refreshView();
                     return true;
                 }
@@ -110,7 +110,7 @@ public class MainActivity extends LockableActivity {
             public void onItemClick(final AdapterView<?> parent, final View view,
                     final int position, final long id) {
                 if (adapter.getItem(position) instanceof Bank) {
-                    selected_bank = (Bank) adapter.getItem(position);
+                    selectedBank = (Bank) adapter.getItem(position);
                     final PopupMenuBank pmenu = new PopupMenuBank(parent, view, MainActivity.this);
                     pmenu.showLikeQuickAction(0, 12);
                 } else {
@@ -241,7 +241,7 @@ public class MainActivity extends LockableActivity {
             final Button btnHide = (Button) root.findViewById(R.id.btnHide);
             final Button btnUnhide = (Button) root.findViewById(R.id.btnUnhide);
             final Button btnWWW = (Button) root.findViewById(R.id.btnWWW);
-            if (selected_bank.getHideAccounts()) {
+            if (selectedBank.getHideAccounts()) {
                 btnHide.setVisibility(View.GONE);
                 btnUnhide.setVisibility(View.VISIBLE);
                 btnUnhide.setOnClickListener(this);
@@ -250,7 +250,7 @@ public class MainActivity extends LockableActivity {
                 btnUnhide.setVisibility(View.GONE);
                 btnHide.setOnClickListener(this);
             }
-            if (selected_bank.isWebViewEnabled()) {
+            if (selectedBank.isWebViewEnabled()) {
                 btnWWW.setOnClickListener(this);
             } else {
                 btnWWW.setVisibility(View.GONE);
@@ -270,29 +270,29 @@ public class MainActivity extends LockableActivity {
                 case R.id.btnHide:
                 case R.id.btnUnhide:
                     this.dismiss();
-                    selected_bank.toggleHideAccounts();
-                    DBAdapter.save(selected_bank, context);
+                    selectedBank.toggleHideAccounts();
+                    DBAdapter.save(selectedBank, context);
                     parent.refreshView();
                     return;
                 case R.id.btnWWW:
-                    if (selected_bank != null && selected_bank.isWebViewEnabled()) {
-                        //Uri uri = Uri.parse(selected_bank.getURL());
+                    if (selectedBank != null && selectedBank.isWebViewEnabled()) {
+                        //Uri uri = Uri.parse(selectedBank.getURL());
                         //Intent intent = new Intent(Intent.ACTION_VIEW, uri);
                         final Intent intent = new Intent(context, WebViewActivity.class);
-                        intent.putExtra("bankid", selected_bank.getDbId());
+                        intent.putExtra("bankid", selectedBank.getDbId());
                         context.startActivity(intent);
                     }
                     this.dismiss();
                     return;
                 case R.id.btnEdit:
                     final Intent intent = new Intent(context, BankEditActivity.class);
-                    intent.putExtra("id", selected_bank.getDbId());
+                    intent.putExtra("id", selectedBank.getDbId());
                     context.startActivity(intent);
                     this.dismiss();
                     return;
                 case R.id.btnRefresh:
                     this.dismiss();
-                    new DataRetrieverTask(parent, selected_bank.getDbId()).execute();
+                    new DataRetrieverTask(parent, selectedBank.getDbId()).execute();
                     return;
                 case R.id.btnRemove:
                     this.dismiss();
@@ -307,7 +307,7 @@ public class MainActivity extends LockableActivity {
                                         public void onClick(final DialogInterface dialog,
                                                 final int id) {
                                             final DBAdapter db = new DBAdapter(context);
-                                            db.deleteBank(selected_bank.getDbId());
+                                            db.deleteBank(selectedBank.getDbId());
                                             dialog.cancel();
                                             parent.refreshView();
                                         }
@@ -358,7 +358,7 @@ public class MainActivity extends LockableActivity {
                     .findViewById(R.id.btnDisableNotifications);
             final Button btnEnableNotifications = (Button) root
                     .findViewById(R.id.btnEnableNotifications);
-            if (selected_account.isHidden()) {
+            if (selectedAccount.isHidden()) {
                 btnHide.setVisibility(View.GONE);
                 btnUnhide.setVisibility(View.VISIBLE);
                 btnUnhide.setOnClickListener(this);
@@ -367,7 +367,7 @@ public class MainActivity extends LockableActivity {
                 btnUnhide.setVisibility(View.GONE);
                 btnHide.setOnClickListener(this);
             }
-            if (selected_account.isNotify()) {
+            if (selectedAccount.isNotify()) {
                 btnDisableNotifications.setVisibility(View.VISIBLE);
                 btnDisableNotifications.setOnClickListener(this);
                 btnEnableNotifications.setVisibility(View.GONE);
@@ -385,26 +385,26 @@ public class MainActivity extends LockableActivity {
             switch (id) {
                 case R.id.btnHide:
                     this.dismiss();
-                    selected_account.setHidden(true);
-                    DBAdapter.save(selected_account.getBank(), parent);
+                    selectedAccount.setHidden(true);
+                    DBAdapter.save(selectedAccount.getBank(), parent);
                     parent.refreshView();
                     return;
                 case R.id.btnUnhide:
                     this.dismiss();
-                    selected_account.setHidden(false);
-                    DBAdapter.save(selected_account.getBank(), parent);
+                    selectedAccount.setHidden(false);
+                    DBAdapter.save(selectedAccount.getBank(), parent);
                     parent.refreshView();
                     return;
                 case R.id.btnEnableNotifications:
                     this.dismiss();
-                    selected_account.setNotify(true);
-                    DBAdapter.save(selected_account.getBank(), parent);
+                    selectedAccount.setNotify(true);
+                    DBAdapter.save(selectedAccount.getBank(), parent);
                     parent.refreshView();
                     return;
                 case R.id.btnDisableNotifications:
                     this.dismiss();
-                    selected_account.setNotify(false);
-                    DBAdapter.save(selected_account.getBank(), parent);
+                    selectedAccount.setNotify(false);
+                    DBAdapter.save(selectedAccount.getBank(), parent);
                     parent.refreshView();
                     return;
 

--- a/app/src/main/java/com/liato/bankdroid/appwidget/AutoRefreshService.java
+++ b/app/src/main/java/com/liato/bankdroid/appwidget/AutoRefreshService.java
@@ -394,15 +394,15 @@ public class AutoRefreshService extends Service {
                     }
                 } catch (final BankException e) {
                     // Refresh widgets if an update fails
-                    Timber.e(e, "Could not update bank %s", bank.getShortName());
+                    Timber.e(e, "Could not update bank %s", bank.getName());
                 } catch (final LoginException e) {
-                    Timber.d(e, "Invalid credentials for bank %s", bank.getShortName());
+                    Timber.d(e, "Invalid credentials for bank %s", bank.getName());
                     refreshWidgets = true;
                     db.disableBank(bank.getDbId());
                 } catch (BankChoiceException e) {
                     Timber.w(e, "BankChoiceException");
                 } catch (Exception e) {
-                    Timber.e(e, "An unexpected error occurred while updating bank %s", bank.getShortName());
+                    Timber.e(e, "An unexpected error occurred while updating bank %s", bank.getName());
                 }
             }
 

--- a/app/src/main/java/com/liato/bankdroid/appwidget/BankdroidWidgetProvider.java
+++ b/app/src/main/java/com/liato/bankdroid/appwidget/BankdroidWidgetProvider.java
@@ -390,15 +390,15 @@ public abstract class BankdroidWidgetProvider extends AppWidgetProvider {
                     }
 
                 } catch (BankException e) {
-                    Timber.e(e, "Could not update bank %s", bank.getShortName());
+                    Timber.e(e, "Could not update bank %s", bank.getName());
                 } catch (LoginException e) {
-                    Timber.w(e, "Invalid credentials for bank %s", bank.getShortName());
+                    Timber.w(e, "Invalid credentials for bank %s", bank.getName());
                     DBAdapter.disable(bank, context);
                 } catch (BankChoiceException e) {
                     Timber.w(e, "BankChoiceException");
                 } catch (IOException e) {
                     if (NetworkUtils.isInternetAvailable()) {
-                        Timber.e(e, "Could not update bank %s", bank.getShortName());
+                        Timber.e(e, "Could not update bank %s", bank.getName());
                     }
                 }
                 BankdroidWidgetProvider.updateAppWidget(context, appWidgetManager, appWidgetId);

--- a/app/src/main/java/com/liato/bankdroid/provider/BankTransactionsProvider.java
+++ b/app/src/main/java/com/liato/bankdroid/provider/BankTransactionsProvider.java
@@ -67,44 +67,44 @@ public class BankTransactionsProvider extends ContentProvider implements
 
     private static final String TRANSACTIONS_TABLE = "transactions";
 
-    private final static UriMatcher uriMatcher;
+    private final static UriMatcher URI_MATCHER;
 
-    private final static Map<String, String> bankAccountProjectionMap;
+    private final static Map<String, String> BANK_ACCOUNT_PROJECTION_MAP;
 
-    private final static Map<String, String> transProjectionMap;
+    private final static Map<String, String> TRANS_PROJECTION_MAP;
 
     static {
-        uriMatcher = new UriMatcher(UriMatcher.NO_MATCH);
-        uriMatcher.addURI(AUTHORITY, TRANSACTIONS_CAT + "/" + WILD_CARD,
+        URI_MATCHER = new UriMatcher(UriMatcher.NO_MATCH);
+        URI_MATCHER.addURI(AUTHORITY, TRANSACTIONS_CAT + "/" + WILD_CARD,
                 TRANSACTIONS);
-        uriMatcher.addURI(AUTHORITY, BANK_ACCOUNTS_CAT + "/" + WILD_CARD,
+        URI_MATCHER.addURI(AUTHORITY, BANK_ACCOUNTS_CAT + "/" + WILD_CARD,
                 BANK_ACCOUNTS);
 
         // Projections are "Poor mans views" of the data.
-        bankAccountProjectionMap = new HashMap<String, String>();
+        BANK_ACCOUNT_PROJECTION_MAP = new HashMap<String, String>();
 
         // Must match bankAccountProjection in
         // IBankTransactionsProvider#bankAccountProjection
-        bankAccountProjectionMap.put(BANK_ID, BANK_ID);
-        bankAccountProjectionMap.put(BANK_NAME, BANK_NAME);
-        bankAccountProjectionMap.put(BANK_TYPE, BANK_TYPE);
-        bankAccountProjectionMap.put(BANK_LAST_UPDATED, BANK_LAST_UPDATED);
-        bankAccountProjectionMap.put(ACC_ID, ACC_ID);
-        bankAccountProjectionMap.put(ACC_NAME, ACC_NAME);
+        BANK_ACCOUNT_PROJECTION_MAP.put(BANK_ID, BANK_ID);
+        BANK_ACCOUNT_PROJECTION_MAP.put(BANK_NAME, BANK_NAME);
+        BANK_ACCOUNT_PROJECTION_MAP.put(BANK_TYPE, BANK_TYPE);
+        BANK_ACCOUNT_PROJECTION_MAP.put(BANK_LAST_UPDATED, BANK_LAST_UPDATED);
+        BANK_ACCOUNT_PROJECTION_MAP.put(ACC_ID, ACC_ID);
+        BANK_ACCOUNT_PROJECTION_MAP.put(ACC_NAME, ACC_NAME);
         // Table name has to be explicitly included here since Banks also have a column named balance.
-        bankAccountProjectionMap.put(ACC_BALANCE, ACCOUNT_TABLE + "." + ACC_BALANCE);
-        bankAccountProjectionMap.put(ACC_TYPE, ACC_TYPE);
+        BANK_ACCOUNT_PROJECTION_MAP.put(ACC_BALANCE, ACCOUNT_TABLE + "." + ACC_BALANCE);
+        BANK_ACCOUNT_PROJECTION_MAP.put(ACC_TYPE, ACC_TYPE);
 
-        transProjectionMap = new HashMap<String, String>();
+        TRANS_PROJECTION_MAP = new HashMap<String, String>();
 
         // Must match transactionProjection in
         // IBankTransactionsProvider#transactionProjection
-        transProjectionMap.put(TRANS_ID, TRANS_ID);
-        transProjectionMap.put(TRANS_DATE, TRANS_DATE);
-        transProjectionMap.put(TRANS_DESC, TRANS_DESC);
-        transProjectionMap.put(TRANS_AMT, TRANS_AMT);
-        transProjectionMap.put(TRANS_CUR, TRANS_CUR);
-        transProjectionMap.put(TRANS_ACCNT, TRANS_ACCNT);
+        TRANS_PROJECTION_MAP.put(TRANS_ID, TRANS_ID);
+        TRANS_PROJECTION_MAP.put(TRANS_DATE, TRANS_DATE);
+        TRANS_PROJECTION_MAP.put(TRANS_DESC, TRANS_DESC);
+        TRANS_PROJECTION_MAP.put(TRANS_AMT, TRANS_AMT);
+        TRANS_PROJECTION_MAP.put(TRANS_CUR, TRANS_CUR);
+        TRANS_PROJECTION_MAP.put(TRANS_ACCNT, TRANS_ACCNT);
     }
 
     private DatabaseHelper dbHelper;
@@ -143,7 +143,7 @@ public class BankTransactionsProvider extends ContentProvider implements
     public String getType(final Uri uri) {
         Timber.d("Got URI: %s", uri.toString());
 
-        switch (uriMatcher.match(uri)) {
+        switch (URI_MATCHER.match(uri)) {
             case BANK_ACCOUNTS:
                 return BANK_ACCOUNTS_MIME;
             case TRANSACTIONS:
@@ -207,12 +207,12 @@ public class BankTransactionsProvider extends ContentProvider implements
         if (BANK_ACCOUNTS_MIME.equals(getType(uri))) {
             qb = new SQLiteQueryBuilder();
             qb.setTables(BANK_ACCOUNT_TABLES);
-            qb.setProjectionMap(bankAccountProjectionMap);
+            qb.setProjectionMap(BANK_ACCOUNT_PROJECTION_MAP);
             qb.setDistinct(true);
         } else if (TRANSACTIONS_MIME.equals(getType(uri))) {
             qb = new SQLiteQueryBuilder();
             qb.setTables(TRANSACTIONS_TABLE);
-            qb.setProjectionMap(transProjectionMap);
+            qb.setProjectionMap(TRANS_PROJECTION_MAP);
         } else {
             throw new IllegalArgumentException("Unsupported URI: " + uri);
         }

--- a/app/src/main/java/net/margaritov/preference/colorpicker/ColorPickerPreference.java
+++ b/app/src/main/java/net/margaritov/preference/colorpicker/ColorPickerPreference.java
@@ -41,7 +41,7 @@ public class ColorPickerPreference
         Preference.OnPreferenceClickListener,
         ColorPickerDialog.OnColorChangedListener {
 
-    private static final String androidns = "http://schemas.android.com/apk/res/android";
+    private static final String ANDROID_NS = "http://schemas.android.com/apk/res/android";
 
     private ViewGroup parent;
 
@@ -137,7 +137,7 @@ public class ColorPickerPreference
         mDensity = getContext().getResources().getDisplayMetrics().density;
         setOnPreferenceClickListener(this);
         if (attrs != null) {
-            String defaultValue = attrs.getAttributeValue(androidns, "defaultValue");
+            String defaultValue = attrs.getAttributeValue(ANDROID_NS, "defaultValue");
             if (defaultValue.startsWith("#")) {
                 try {
                     mDefaultValue = convertToColorInt(defaultValue);
@@ -146,7 +146,7 @@ public class ColorPickerPreference
                     mDefaultValue = convertToColorInt("#FF000000");
                 }
             } else {
-                int resourceId = attrs.getAttributeResourceValue(androidns, "defaultValue", 0);
+                int resourceId = attrs.getAttributeResourceValue(ANDROID_NS, "defaultValue", 0);
                 if (resourceId != 0) {
                     mDefaultValue = context.getResources().getInteger(resourceId);
                 }

--- a/app/src/main/java/net/margaritov/preference/colorpicker/ColorPickerView.java
+++ b/app/src/main/java/net/margaritov/preference/colorpicker/ColorPickerView.java
@@ -64,29 +64,29 @@ public class ColorPickerView extends View {
     /**
      * The width in dp of the hue panel.
      */
-    private float HUE_PANEL_WIDTH = 30f;
+    private float huePanelWidth = 30f;
 
     /**
      * The height in dp of the alpha panel
      */
-    private float ALPHA_PANEL_HEIGHT = 20f;
+    private float alphaPanelHeight = 20f;
 
     /**
      * The distance in dp between the different
      * color panels.
      */
-    private float PANEL_SPACING = 10f;
+    private float panelSpacing = 10f;
 
     /**
      * The radius in dp of the color palette tracker circle.
      */
-    private float PALETTE_CIRCLE_TRACKER_RADIUS = 5f;
+    private float paletteCircleTrackerRadius = 5f;
 
     /**
      * The dp which the tracker of the hue or alpha panel
      * will extend outside of its bounds.
      */
-    private float RECTANGLE_TRACKER_OFFSET = 2f;
+    private float rectangleTrackerOffset = 2f;
 
     private float mDensity = 1f;
 
@@ -172,11 +172,11 @@ public class ColorPickerView extends View {
             setLayerType(View.LAYER_TYPE_SOFTWARE, null);
         }
         mDensity = getContext().getResources().getDisplayMetrics().density;
-        PALETTE_CIRCLE_TRACKER_RADIUS *= mDensity;
-        RECTANGLE_TRACKER_OFFSET *= mDensity;
-        HUE_PANEL_WIDTH *= mDensity;
-        ALPHA_PANEL_HEIGHT *= mDensity;
-        PANEL_SPACING = PANEL_SPACING * mDensity;
+        paletteCircleTrackerRadius *= mDensity;
+        rectangleTrackerOffset *= mDensity;
+        huePanelWidth *= mDensity;
+        alphaPanelHeight *= mDensity;
+        panelSpacing = panelSpacing * mDensity;
 
         mDrawingOffset = calculateRequiredOffset();
 
@@ -216,7 +216,7 @@ public class ColorPickerView extends View {
     }
 
     private float calculateRequiredOffset() {
-        float offset = Math.max(PALETTE_CIRCLE_TRACKER_RADIUS, RECTANGLE_TRACKER_OFFSET);
+        float offset = Math.max(paletteCircleTrackerRadius, rectangleTrackerOffset);
         offset = Math.max(offset, BORDER_WIDTH_PX * mDensity);
 
         return offset * 1.5f;
@@ -274,11 +274,11 @@ public class ColorPickerView extends View {
         Point p = satValToPoint(mSat, mVal);
 
         mSatValTrackerPaint.setColor(0xff000000);
-        canvas.drawCircle(p.x, p.y, PALETTE_CIRCLE_TRACKER_RADIUS - 1f * mDensity,
+        canvas.drawCircle(p.x, p.y, paletteCircleTrackerRadius - 1f * mDensity,
                 mSatValTrackerPaint);
 
         mSatValTrackerPaint.setColor(0xffdddddd);
-        canvas.drawCircle(p.x, p.y, PALETTE_CIRCLE_TRACKER_RADIUS, mSatValTrackerPaint);
+        canvas.drawCircle(p.x, p.y, paletteCircleTrackerRadius, mSatValTrackerPaint);
 
     }
 
@@ -308,8 +308,8 @@ public class ColorPickerView extends View {
         Point p = hueToPoint(mHue);
 
         RectF r = new RectF();
-        r.left = rect.left - RECTANGLE_TRACKER_OFFSET;
-        r.right = rect.right + RECTANGLE_TRACKER_OFFSET;
+        r.left = rect.left - rectangleTrackerOffset;
+        r.right = rect.right + rectangleTrackerOffset;
         r.top = p.y - rectHeight;
         r.bottom = p.y + rectHeight;
 
@@ -359,8 +359,8 @@ public class ColorPickerView extends View {
         RectF r = new RectF();
         r.left = p.x - rectWidth;
         r.right = p.x + rectWidth;
-        r.top = rect.top - RECTANGLE_TRACKER_OFFSET;
-        r.bottom = rect.bottom + RECTANGLE_TRACKER_OFFSET;
+        r.top = rect.top - rectangleTrackerOffset;
+        r.bottom = rect.bottom + rectangleTrackerOffset;
 
         canvas.drawRoundRect(r, 2, 2, mHueTrackerPaint);
 
@@ -663,22 +663,22 @@ public class ColorPickerView extends View {
 
         if (!mShowAlphaPanel) {
 
-            height = (int) (widthAllowed - PANEL_SPACING - HUE_PANEL_WIDTH);
+            height = (int) (widthAllowed - panelSpacing - huePanelWidth);
 
             //If calculated height (based on the width) is more than the allowed height.
             if (height > heightAllowed || getTag().equals("landscape")) {
                 height = heightAllowed;
-                width = (int) (height + PANEL_SPACING + HUE_PANEL_WIDTH);
+                width = (int) (height + panelSpacing + huePanelWidth);
             } else {
                 width = widthAllowed;
             }
         } else {
 
-            width = (int) (heightAllowed - ALPHA_PANEL_HEIGHT + HUE_PANEL_WIDTH);
+            width = (int) (heightAllowed - alphaPanelHeight + huePanelWidth);
 
             if (width > widthAllowed) {
                 width = widthAllowed;
-                height = (int) (widthAllowed - HUE_PANEL_WIDTH + ALPHA_PANEL_HEIGHT);
+                height = (int) (widthAllowed - huePanelWidth + alphaPanelHeight);
             } else {
                 height = heightAllowed;
             }
@@ -709,10 +709,10 @@ public class ColorPickerView extends View {
         int width = getPrefferedHeight();
 
         if (mShowAlphaPanel) {
-            width -= (PANEL_SPACING + ALPHA_PANEL_HEIGHT);
+            width -= (panelSpacing + alphaPanelHeight);
         }
 
-        return (int) (width + HUE_PANEL_WIDTH + PANEL_SPACING);
+        return (int) (width + huePanelWidth + panelSpacing);
 
     }
 
@@ -721,7 +721,7 @@ public class ColorPickerView extends View {
         int height = (int) (200 * mDensity);
 
         if (mShowAlphaPanel) {
-            height += PANEL_SPACING + ALPHA_PANEL_HEIGHT;
+            height += panelSpacing + alphaPanelHeight;
         }
 
         return height;
@@ -748,7 +748,7 @@ public class ColorPickerView extends View {
         float panelSide = dRect.height() - BORDER_WIDTH_PX * 2;
 
         if (mShowAlphaPanel) {
-            panelSide -= PANEL_SPACING + ALPHA_PANEL_HEIGHT;
+            panelSide -= panelSpacing + alphaPanelHeight;
         }
 
         float left = dRect.left + BORDER_WIDTH_PX;
@@ -762,10 +762,10 @@ public class ColorPickerView extends View {
     private void setUpHueRect() {
         final RectF dRect = mDrawingRect;
 
-        float left = dRect.right - HUE_PANEL_WIDTH + BORDER_WIDTH_PX;
+        float left = dRect.right - huePanelWidth + BORDER_WIDTH_PX;
         float top = dRect.top + BORDER_WIDTH_PX;
-        float bottom = dRect.bottom - BORDER_WIDTH_PX - (mShowAlphaPanel ? (PANEL_SPACING
-                + ALPHA_PANEL_HEIGHT) : 0);
+        float bottom = dRect.bottom - BORDER_WIDTH_PX - (mShowAlphaPanel ? (panelSpacing
+                + alphaPanelHeight) : 0);
         float right = dRect.right - BORDER_WIDTH_PX;
 
         mHueRect = new RectF(left, top, right, bottom);
@@ -780,7 +780,7 @@ public class ColorPickerView extends View {
         final RectF dRect = mDrawingRect;
 
         float left = dRect.left + BORDER_WIDTH_PX;
-        float top = dRect.bottom - ALPHA_PANEL_HEIGHT + BORDER_WIDTH_PX;
+        float top = dRect.bottom - alphaPanelHeight + BORDER_WIDTH_PX;
         float bottom = dRect.bottom - BORDER_WIDTH_PX;
         float right = dRect.right - BORDER_WIDTH_PX;
 

--- a/app/src/test/java/com/liato/bankdroid/appwidget/DataRetrieverTaskTest.java
+++ b/app/src/test/java/com/liato/bankdroid/appwidget/DataRetrieverTaskTest.java
@@ -3,6 +3,7 @@ package com.liato.bankdroid.appwidget;
 import com.liato.bankdroid.banking.Account;
 import com.liato.bankdroid.banking.Bank;
 import com.liato.bankdroid.db.DBAdapter;
+import com.liato.bankdroid.provider.IBankTypes;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -55,6 +56,16 @@ public class DataRetrieverTaskTest {
         @Override
         public BigDecimal getBalance() {
             return getAccounts().get(0).getBalance();
+        }
+
+        @Override
+        public int getBanktypeId() {
+            return IBankTypes.TESTBANK;
+        }
+
+        @Override
+        public String getName() {
+            return "Testbanken";
         }
     }
 

--- a/bankdroid-core/src/main/java/com/liato/bankdroid/configuration/DefaultConnectionConfiguration.java
+++ b/bankdroid-core/src/main/java/com/liato/bankdroid/configuration/DefaultConnectionConfiguration.java
@@ -12,7 +12,7 @@ public class DefaultConnectionConfiguration {
 
     public static final String NAME = "provider.configuration.name";
 
-    private final static List<Field> configuration = createConfiguration();
+    private final static List<Field> CONFIGURATION = createConfiguration();
 
     private static List<Field> createConfiguration() {
         List<Field> configuration = new ArrayList<>();
@@ -24,6 +24,6 @@ public class DefaultConnectionConfiguration {
     }
 
     public static List<Field> fields() {
-        return configuration;
+        return CONFIGURATION;
     }
 }

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/Helpers.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/Helpers.java
@@ -38,7 +38,7 @@ import timber.log.Timber;
 public class Helpers {
     private static final StrikethroughSpan STRIKE_THROUGH_SPAN = new StrikethroughSpan();
 
-    private final static String[] currencies = {"AED", "AFN", "ALL", "AMD", "ANG", "AOA", "ARS",
+    private final static String[] CURRENCIES = {"AED", "AFN", "ALL", "AMD", "ANG", "AOA", "ARS",
             "AUD",
             "AWG", "AZN", "BAM", "BBD", "BDT", "BGN", "BHD", "BIF",
             "BMD", "BND", "BOB", "BRL", "BSD", "BTN", "BWP", "BYR",
@@ -62,7 +62,7 @@ public class Helpers {
             "XAU", "XCD", "XDR", "XOF", "XPD", "XPF", "XPT", "YER",
             "ZAR", "ZMK", "ZWD"};
 
-    private final static String[][] symMappings = {{"$U", "UYU"}, {"$b", "BOB"}, {"BZ$", "BZD"},
+    private final static String[][] SYM_MAPPINGS = {{"$U", "UYU"}, {"$b", "BOB"}, {"BZ$", "BZD"},
             {"C$", "NIO"}, {"J$", "JMD"}, {"NT$", "TWD"},
             {"R$", "BRL"}, {"RD$", "DOP"}, {"TT$", "TTD"},
             {"Z$", "ZWD"}, {"$", "USD"}, {"B/.", "PAB"},
@@ -148,12 +148,12 @@ public class Helpers {
 
     public static String parseCurrency(String text, String def) {
         text = text != null ? text.toLowerCase() : "";
-        for (String currency : currencies) {
+        for (String currency : CURRENCIES) {
             if (text.contains(currency)) {
                 return currency;
             }
         }
-        for (String[] symCur : symMappings) {
+        for (String[] symCur : SYM_MAPPINGS) {
             if (text.contains(symCur[0])) {
                 return symCur[1];
             }

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/Bank.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/Bank.java
@@ -54,14 +54,6 @@ public abstract class Bank implements Comparable<Bank>, IBankTypes {
     @DrawableRes
     private final int logoResource;
 
-    protected String TAG = "Bank";
-
-    protected String NAME = "Bank";
-
-    protected String NAME_SHORT = "bank";
-
-    protected int BANKTYPE_ID = 0;
-
     /**
      * URL for human-accessible web bank.
      * <p/>
@@ -71,43 +63,43 @@ public abstract class Bank implements Comparable<Bank>, IBankTypes {
      * @see #isWebViewEnabled()
      */
     @Nullable
-    protected String URL;
+    protected String url;
 
-    protected int INPUT_TYPE_USERNAME = InputType.TYPE_CLASS_TEXT;
+    protected int inputTypeUsername = InputType.TYPE_CLASS_TEXT;
 
-    protected int INPUT_TYPE_PASSWORD = InputType.TYPE_CLASS_TEXT
+    protected int inputTypePassword = InputType.TYPE_CLASS_TEXT
             | InputType.TYPE_TEXT_VARIATION_PASSWORD;
 
-    protected int INPUT_TYPE_EXTRAS = InputType.TYPE_CLASS_TEXT;
+    private static final int INPUT_TYPE_EXTRAS = InputType.TYPE_CLASS_TEXT;
 
-    protected String INPUT_HINT_USERNAME = null;
+    protected String inputHintUsername = null;
 
-    protected boolean INPUT_HIDDEN_USERNAME = false;
+    private static final boolean INPUT_HIDDEN_USERNAME = false;
 
-    protected boolean INPUT_HIDDEN_PASSWORD = false;
+    protected boolean inputHiddenPassword = false;
 
-    protected boolean INPUT_HIDDEN_EXTRAS = true;
+    private static final boolean INPUT_HIDDEN_EXTRAS = true;
 
-    protected int INPUT_TITLETEXT_USERNAME = R.string.username;
+    protected int inputTitletextUsername = R.string.username;
 
-    protected int INPUT_TITLETEXT_PASSWORD = R.string.password;
+    private final int INPUT_TITLETEXT_PASSWORD = R.string.password;
 
-    protected int INPUT_TITLETEXT_EXTRAS = R.string.extras_field;
+    private final int INPUT_TITLETEXT_EXTRAS = R.string.extras_field;
 
-    protected boolean STATIC_BALANCE = false;
+    protected boolean staticBalance = false;
 
-    protected boolean BROKEN = false;
+    private static final boolean BROKEN = false;
 
-    protected boolean DISPLAY_DECIMALS = true;
+    protected boolean displayDecimals = true;
 
     /**
      * Whether or not we support opening the web version of a bank.
      * <p/>
      * Lots of banks don't have this any more, but have apps instead.
      * @see #isWebViewEnabled()
-     * @see #URL
+     * @see #url
      */
-    protected boolean WEB_VIEW_ENABLED = true;
+    protected boolean webViewEnabled = true;
 
     protected Context context;
 
@@ -229,7 +221,7 @@ public abstract class Bank implements Comparable<Bank>, IBankTypes {
     }
 
     public BigDecimal getBalance() {
-        if (STATIC_BALANCE) {
+        if (staticBalance) {
             return balance;
         } else {
             BigDecimal bal = new BigDecimal(0);
@@ -246,13 +238,9 @@ public abstract class Bank implements Comparable<Bank>, IBankTypes {
         }
     }
 
-    public int getBanktypeId() {
-        return BANKTYPE_ID;
-    }
+    public abstract int getBanktypeId();
 
-    public String getName() {
-        return NAME;
-    }
+    public abstract String getName();
 
     public String getDisplayName() {
         if (customName != null && customName.length() > 0) {
@@ -277,10 +265,6 @@ public abstract class Bank implements Comparable<Bank>, IBankTypes {
     public void setExtras(String extras) {
         getProperties().put(LegacyProviderConfiguration.EXTRAS, extras);
       }
-
-    public String getShortName() {
-        return NAME_SHORT;
-    }
 
     public void setData(BigDecimal balance,
             boolean disabled, long dbid, String currency, String customName,
@@ -314,15 +298,15 @@ public abstract class Bank implements Comparable<Bank>, IBankTypes {
     }
 
     public String getURL() {
-        return URL;
+        return url;
     }
 
     public int getInputTypeUsername() {
-        return INPUT_TYPE_USERNAME;
+        return inputTypeUsername;
     }
 
     public int getInputTypePassword() {
-        return INPUT_TYPE_PASSWORD;
+        return inputTypePassword;
     }
 
     public int getInputTypeExtras() {
@@ -330,7 +314,7 @@ public abstract class Bank implements Comparable<Bank>, IBankTypes {
     }
 
     public String getInputHintUsername() {
-        return INPUT_HINT_USERNAME;
+        return inputHintUsername;
     }
 
     public boolean isInputUsernameHidden() {
@@ -338,7 +322,7 @@ public abstract class Bank implements Comparable<Bank>, IBankTypes {
     }
 
     public boolean isInputPasswordHidden() {
-        return INPUT_HIDDEN_PASSWORD;
+        return inputHiddenPassword;
     }
 
     public boolean isInputExtrasHidden() {
@@ -346,7 +330,7 @@ public abstract class Bank implements Comparable<Bank>, IBankTypes {
     }
 
     public int getInputTitleUsername() {
-        return INPUT_TITLETEXT_USERNAME;
+        return inputTitletextUsername;
     }
 
     public int getInputTitlePassword() {
@@ -361,11 +345,11 @@ public abstract class Bank implements Comparable<Bank>, IBankTypes {
      * Whether or not we support opening the web version of a bank.
      * <p/>
      * Lots of banks don't have this any more, but have apps instead.
-     * @see #WEB_VIEW_ENABLED
-     * @see #URL
+     * @see #webViewEnabled
+     * @see #url
      */
     public boolean isWebViewEnabled() {
-        return URL != null && WEB_VIEW_ENABLED;
+        return url != null && webViewEnabled;
     }
 
     public Map<String, String> getProperties() {
@@ -455,7 +439,7 @@ public abstract class Bank implements Comparable<Bank>, IBankTypes {
             Timber.e(e, "Error getting session package");
         }
         String html = String.format(preloader,
-                String.format("function go(){window.location=\"%s\" }", this.URL),
+                String.format("function go(){window.location=\"%s\" }", this.url),
                 // Javascript function
                 "<script type=\"text/javascript\">setTimeout('go()', 1000);</script>" // HTML
         );
@@ -467,7 +451,7 @@ public abstract class Bank implements Comparable<Bank>, IBankTypes {
     }
 
     public boolean getDisplayDecimals() {
-        return DISPLAY_DECIMALS;
+        return displayDecimals;
     }
 
     protected Context getContext() {

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/AbsIkanoPartner.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/AbsIkanoPartner.java
@@ -58,10 +58,10 @@ public abstract class AbsIkanoPartner extends Bank {
 
     public AbsIkanoPartner(Context context, @DrawableRes int logoResource) {
         super(context, logoResource);
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
-        super.INPUT_TYPE_PASSWORD = INPUT_TYPE_PASSWORD;
-        super.INPUT_HINT_USERNAME = INPUT_HINT_USERNAME;
-        super.STATIC_BALANCE = true;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+        super.inputTypePassword = INPUT_TYPE_PASSWORD;
+        super.inputHintUsername = INPUT_HINT_USERNAME;
+        super.staticBalance = true;
     }
 
     public AbsIkanoPartner(String username, String password, Context context, @DrawableRes int logoResource)

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/AkeliusInvest.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/AkeliusInvest.java
@@ -46,8 +46,6 @@ public class AkeliusInvest extends Bank {
 
     private static final String NAME = "Akelius Invest";
 
-    private static final String NAME_SHORT = "akeliusinvest";
-
     private static final String URL = "https://online.akeliusinvest.com/";
 
     private static final int BANKTYPE_ID = IBankTypes.AKELIUSINVEST;
@@ -80,14 +78,11 @@ public class AkeliusInvest extends Bank {
 
     public AkeliusInvest(Context context) {
         super(context, R.drawable.logo_akeliusinvest);
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
-        super.INPUT_TYPE_PASSWORD = INPUT_TYPE_PASSWORD;
-        super.INPUT_HINT_USERNAME = INPUT_HINT_USERNAME;
-        super.STATIC_BALANCE = STATIC_BALANCE;
+        super.url = URL;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+        super.inputTypePassword = INPUT_TYPE_PASSWORD;
+        super.inputHintUsername = INPUT_HINT_USERNAME;
+        super.staticBalance = STATIC_BALANCE;
     }
 
     public AkeliusInvest(String username, String password, Context context) throws BankException,
@@ -135,6 +130,16 @@ public class AkeliusInvest extends Bank {
             }
         }
         return urlopen;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     @Override

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/AkeliusSpar.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/AkeliusSpar.java
@@ -47,8 +47,6 @@ public class AkeliusSpar extends Bank {
 
     private static final String NAME = "Akelius Spar";
 
-    private static final String NAME_SHORT = "akeliusspar";
-
     private static final String URL = "https://www.online.akeliusspar.se/";
 
     private static final int BANKTYPE_ID = IBankTypes.AKELIUSSPAR;
@@ -81,14 +79,21 @@ public class AkeliusSpar extends Bank {
 
     public AkeliusSpar(Context context) {
         super(context, R.drawable.logo_akeliusspar);
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
-        super.INPUT_TYPE_PASSWORD = INPUT_TYPE_PASSWORD;
-        super.INPUT_HINT_USERNAME = INPUT_HINT_USERNAME;
-        super.STATIC_BALANCE = STATIC_BALANCE;
+        super.url = URL;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+        super.inputTypePassword = INPUT_TYPE_PASSWORD;
+        super.inputHintUsername = INPUT_HINT_USERNAME;
+        super.staticBalance = STATIC_BALANCE;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public AkeliusSpar(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/AppeakPoker.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/AppeakPoker.java
@@ -42,8 +42,6 @@ public class AppeakPoker extends Bank {
 
     private static final String NAME = "Appeak Poker";
 
-    private static final String NAME_SHORT = "appeakpoker";
-
     private static final String URL = "http://poker.appeak.se/";
 
     private static final int BANKTYPE_ID = Bank.APPEAKPOKER;
@@ -56,14 +54,21 @@ public class AppeakPoker extends Bank {
 
     public AppeakPoker(Context context) {
         super(context, R.drawable.logo_appeakpoker);
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
-        super.INPUT_HIDDEN_PASSWORD = INPUT_HIDDEN_PASSWORD;
-        super.DISPLAY_DECIMALS = false;
+        super.url = URL;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+        super.inputHiddenPassword = INPUT_HIDDEN_PASSWORD;
+        super.displayDecimals = false;
         currency = "chips";
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public AppeakPoker(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/AvanzaMini.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/AvanzaMini.java
@@ -26,9 +26,16 @@ public class AvanzaMini extends Avanza {
 
     public AvanzaMini(Context context) {
         super(context, R.drawable.logo_avanzamini);
-        NAME = "Avanza Mini";
-        NAME_SHORT = "avanzamini";
-        URL = "https://www.avanza.se/mini/hem/";
-        BANKTYPE_ID = IBankTypes.AVANZAMINI;
+        url = "https://www.avanza.se/mini/hem/";
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return IBankTypes.AVANZAMINI;
+    }
+
+    @Override
+    public String getName() {
+        return "Avanza Mini";
     }
 }

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/BetterGlobe.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/BetterGlobe.java
@@ -44,8 +44,6 @@ public class BetterGlobe extends Bank {
 
     private static final String NAME = "Better Globe";
 
-    private static final String NAME_SHORT = "betterglobe";
-
     private static final String URL = "http://betterglobe.com";
 
     private static final int BANKTYPE_ID = IBankTypes.BETTERGLOBE;
@@ -70,15 +68,22 @@ public class BetterGlobe extends Bank {
 
     public BetterGlobe(Context context) {
         super(context, R.drawable.logo_betterglobe);
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
-        super.INPUT_TYPE_PASSWORD = INPUT_TYPE_PASSWORD;
-        super.INPUT_HINT_USERNAME = INPUT_HINT_USERNAME;
-        super.STATIC_BALANCE = STATIC_BALANCE;
+        super.url = URL;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+        super.inputTypePassword = INPUT_TYPE_PASSWORD;
+        super.inputHintUsername = INPUT_HINT_USERNAME;
+        super.staticBalance = STATIC_BALANCE;
         super.currency = "EUR";
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public BetterGlobe(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Bioklubben.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Bioklubben.java
@@ -46,8 +46,6 @@ public class Bioklubben extends Bank {
 
     private static final String NAME = "Bioklubben";
 
-    private static final String NAME_SHORT = "bioklubben";
-
     private static final String URL = "https://bioklubben.sf.se/Start.aspx";
 
     private static final int BANKTYPE_ID = Bank.BIOKLUBBEN;
@@ -58,15 +56,22 @@ public class Bioklubben extends Bank {
 
     public Bioklubben(Context context) {
         super(context, R.drawable.logo_bioklubben);
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.DISPLAY_DECIMALS = DISPLAY_DECIMALS;
-        super.INPUT_TYPE_USERNAME = InputType.TYPE_CLASS_TEXT
+        super.url = URL;
+        super.displayDecimals = DISPLAY_DECIMALS;
+        super.inputTypeUsername = InputType.TYPE_CLASS_TEXT
                 | +InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS;
-        super.INPUT_HINT_USERNAME = context.getString(R.string.email);
+        super.inputHintUsername = context.getString(R.string.email);
         currency = context.getString(R.string.points);
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public Bioklubben(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/BlekingeTrafiken.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/BlekingeTrafiken.java
@@ -42,8 +42,6 @@ public class BlekingeTrafiken extends Bank {
 
     private static final String NAME = "Blekingetrafiken";
 
-    private static final String NAME_SHORT = "blekingetrafiken";
-
     private static final String URL = "https://www.blekingetrafiken.se";
 
     private static final int BANKTYPE_ID = IBankTypes.BLEKINGETRAFIKEN;
@@ -52,15 +50,21 @@ public class BlekingeTrafiken extends Bank {
 
     public BlekingeTrafiken(Context context) {
         super(context, R.drawable.logo_blekingetrafiken);
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.INPUT_TYPE_USERNAME = InputType.TYPE_CLASS_PHONE;
-        super.INPUT_HINT_USERNAME = "XXXXXXXXXX";
-        super.INPUT_TITLETEXT_USERNAME = R.string.card_number;
-        super.INPUT_HIDDEN_PASSWORD = true;
+        super.url = URL;
+        super.inputTypeUsername = InputType.TYPE_CLASS_PHONE;
+        super.inputHintUsername = "XXXXXXXXXX";
+        super.inputTitletextUsername = R.string.card_number;
+        super.inputHiddenPassword = true;
+    }
 
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public BlekingeTrafiken(String username, String password, Context context)

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Bredband2VoIP.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Bredband2VoIP.java
@@ -63,11 +63,18 @@ public class Bredband2VoIP extends Bank {
 
     public Bredband2VoIP(Context context) {
         super(context, R.drawable.logo_bredband2voip);
-        NAME = "Bredband2 VoIP";
-        NAME_SHORT = "bredband2voip";
-        BANKTYPE_ID = IBankTypes.BREDBAND2VOIP;
-        super.INPUT_TYPE_USERNAME = InputType.TYPE_CLASS_PHONE;
-        super.INPUT_HINT_USERNAME = "19XXXXXX-XXXX";
+        super.inputTypeUsername = InputType.TYPE_CLASS_PHONE;
+        super.inputHintUsername = "19XXXXXX-XXXX";
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return IBankTypes.BREDBAND2VOIP;
+    }
+
+    @Override
+    public String getName() {
+        return "Bredband2 VoIP";
     }
 
     public Bredband2VoIP(String username, String password, Context context)

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/BrummerKF.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/BrummerKF.java
@@ -46,8 +46,6 @@ public class BrummerKF extends Bank {
 
     private static final String NAME = "Brummer KF & Pension";
 
-    private static final String NAME_SHORT = "brummer_kf";
-
     private static final String URL = "https://www.brummer.se/";
 
     private static final int BANKTYPE_ID = IBankTypes.BRUMMER_KF;
@@ -78,14 +76,21 @@ public class BrummerKF extends Bank {
 
     public BrummerKF(Context context) {
         super(context, R.drawable.logo_brummer_kf);
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
-        super.INPUT_TYPE_PASSWORD = INPUT_TYPE_PASSWORD;
-        super.INPUT_HINT_USERNAME = INPUT_HINT_USERNAME;
-        super.STATIC_BALANCE = STATIC_BALANCE;
+        super.url = URL;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+        super.inputTypePassword = INPUT_TYPE_PASSWORD;
+        super.inputHintUsername = INPUT_HINT_USERNAME;
+        super.staticBalance = STATIC_BALANCE;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public BrummerKF(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/CSN.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/CSN.java
@@ -49,8 +49,6 @@ public class CSN extends Bank {
 
     private static final String NAME = "CSN";
 
-    private static final String NAME_SHORT = "csn";
-
     private static final String URL = "https://www.csn.se/bas/inloggning/pinkod.do";
 
     private static final int BANKTYPE_ID = IBankTypes.CSN;
@@ -82,14 +80,21 @@ public class CSN extends Bank {
 
     public CSN(Context context) {
         super(context, R.drawable.logo_csn);
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.INPUT_TYPE_PASSWORD = INPUT_TYPE_PASSWORD;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
-        super.INPUT_HINT_USERNAME = INPUT_HINT_USERNAME;
-        super.STATIC_BALANCE = STATIC_BALANCE;
+        super.url = URL;
+        super.inputTypePassword = INPUT_TYPE_PASSWORD;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+        super.inputHintUsername = INPUT_HINT_USERNAME;
+        super.staticBalance = STATIC_BALANCE;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public CSN(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Chalmrest.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Chalmrest.java
@@ -28,8 +28,6 @@ public class Chalmrest extends Bank {
 
     private static final String NAME = "Chalmrest";
 
-    private static final String NAME_SHORT = "chalmrest";
-
     private static final int BANKTYPE_ID = IBankTypes.CHALMREST;
 
     private Pattern reViewState = Pattern.compile("__VIEWSTATE\"\\s+value=\"([^\"]+)\"");
@@ -47,13 +45,20 @@ public class Chalmrest extends Bank {
 
     public Chalmrest(Context context) {
         super(context, R.drawable.logo_chalmrest);
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.INPUT_TITLETEXT_USERNAME = R.string.card_number;
-        super.INPUT_HINT_USERNAME = "XXXXXXXXXXXXXXXX";
-        super.INPUT_TYPE_USERNAME = InputType.TYPE_CLASS_NUMBER;
-        super.INPUT_HIDDEN_PASSWORD = true;
+        super.inputTitletextUsername = R.string.card_number;
+        super.inputHintUsername = "XXXXXXXXXXXXXXXX";
+        super.inputTypeUsername = InputType.TYPE_CLASS_NUMBER;
+        super.inputHiddenPassword = true;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public Chalmrest(String username, String password, Context context) throws BankException,
@@ -110,30 +115,30 @@ public class Chalmrest extends Bank {
         }
         urlopen = login();
         response = urlopen.open("http://kortladdning3.chalmerskonferens.se/CardLoad_Order.aspx");
-        Matcher matcher;
-        Matcher matcher_b;
+        Matcher accountMatcher;
+        Matcher balanceMatcher;
 
-        matcher = reAccount.matcher(response);
-        if (matcher.find()) {
+        accountMatcher = reAccount.matcher(response);
+        if (accountMatcher.find()) {
             /*
              * Capture groups:
              * GROUP                EXAMPLE DATA
              * 1: Name              Kalle Karlsson
              */
 
-            matcher_b = reBalance.matcher(response);
-            if (matcher_b.find()) {
+            balanceMatcher = reBalance.matcher(response);
+            if (balanceMatcher.find()) {
                 /*
                  * Capture groups:
                  * GROUP                EXAMPLE DATA
                  * 1: Balance              118 kr
                  */
 
-                String balanceString = matcher_b.group(1).replaceAll("\\<a[^>]*>", "")
+                String balanceString = balanceMatcher.group(1).replaceAll("\\<a[^>]*>", "")
                         .replaceAll("\\<[^>]*>", "").trim();
 
-                accounts.add(new Account(Html.fromHtml(matcher.group(1)).toString().trim(),
-                        Helpers.parseBalance(balanceString), matcher.group(1)));
+                accounts.add(new Account(Html.fromHtml(accountMatcher.group(1)).toString().trim(),
+                        Helpers.parseBalance(balanceString), accountMatcher.group(1)));
                 balance = balance.add(Helpers.parseBalance(balanceString));
             }
         }

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/DanskeBank.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/DanskeBank.java
@@ -49,8 +49,6 @@ public class DanskeBank extends Bank {
 
     private static final String NAME = "DanskeBank";
 
-    private static final String NAME_SHORT = "danskebank";
-
     private static final String URL
             = "https://mobil.danskebank.se/XI?WP=XAI&WO=Logon&WA=MBSELogon&gsSprog=SE&gsBrand=OEB";
 
@@ -82,13 +80,20 @@ public class DanskeBank extends Bank {
 
     public DanskeBank(Context context) {
         super(context, R.drawable.logo_danskebank);
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
-        super.INPUT_HINT_USERNAME = INPUT_HINT_USERNAME;
-        super.INPUT_TYPE_PASSWORD = INPUT_TYPE_PASSWORD;
+        super.url = URL;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+        super.inputHintUsername = INPUT_HINT_USERNAME;
+        super.inputTypePassword = INPUT_TYPE_PASSWORD;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public DanskeBank(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Everydaycard.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Everydaycard.java
@@ -45,8 +45,6 @@ public class Everydaycard extends Bank {
 
     private static final String NAME = "Everydaycard";
 
-    private static final String NAME_SHORT = "everydaycard";
-
     private static final String URL = "http://www.everydaycard.se/mobil/";
 
     private static final int BANKTYPE_ID = IBankTypes.EVERYDAYCARD;
@@ -67,12 +65,19 @@ public class Everydaycard extends Bank {
 
     public Everydaycard(Context context) {
         super(context, R.drawable.logo_everydaycard);
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
-        super.INPUT_HINT_USERNAME = INPUT_HINT_USERNAME;
+        super.url = URL;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+        super.inputHintUsername = INPUT_HINT_USERNAME;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public Everydaycard(String username, String password, Context context)

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/FirstCard.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/FirstCard.java
@@ -46,8 +46,6 @@ public class FirstCard extends Bank {
 
     private static final String NAME = "First Card";
 
-    private static final String NAME_SHORT = "firstcard";
-
     private static final String URL = "https://www.firstcard.se/login.jsp";
 
     private static final int BANKTYPE_ID = IBankTypes.FIRSTCARD;
@@ -68,12 +66,19 @@ public class FirstCard extends Bank {
 
     public FirstCard(Context context) {
         super(context, R.drawable.logo_firstcard);
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
-        super.INPUT_HINT_USERNAME = INPUT_HINT_USERNAME;
+        super.url = URL;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+        super.inputHintUsername = INPUT_HINT_USERNAME;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public FirstCard(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Hemkop.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Hemkop.java
@@ -50,8 +50,6 @@ public class Hemkop extends Bank {
 
     private static final String NAME = "Hemköp Kundkort";
 
-    private static final String NAME_SHORT = "hemkop";
-
     private static final String URL = "https://www.hemkop.se/Mina-sidor/Logga-in/";
 
     private static final int BANKTYPE_ID = IBankTypes.HEMKOP;
@@ -65,12 +63,19 @@ public class Hemkop extends Bank {
     public Hemkop(Context context) {
         super(context, R.drawable.logo_hemkop);
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
-        super.INPUT_HINT_USERNAME = INPUT_HINT_USERNAME;
+        super.url = URL;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+        super.inputHintUsername = INPUT_HINT_USERNAME;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public Hemkop(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Hors.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Hors.java
@@ -45,8 +45,6 @@ public class Hors extends Bank {
 
     private static final String NAME = "Hörs";
 
-    private static final String NAME_SHORT = "hors";
-
     private static final String URL = "http://www.dittkort.se/hors/";
 
     private static final int BANKTYPE_ID = IBankTypes.HORS;
@@ -58,15 +56,22 @@ public class Hors extends Bank {
     public Hors(Context context) {
         super(context, R.drawable.logo_hors);
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.DISPLAY_DECIMALS = DISPLAY_DECIMALS;
-        super.INPUT_TYPE_USERNAME = InputType.TYPE_CLASS_TEXT
+        super.url = URL;
+        super.displayDecimals = DISPLAY_DECIMALS;
+        super.inputTypeUsername = InputType.TYPE_CLASS_TEXT
                 | +InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS;
-        super.INPUT_HINT_USERNAME = context.getString(R.string.card_id);
-        super.INPUT_HIDDEN_PASSWORD = true;
+        super.inputHintUsername = context.getString(R.string.card_id);
+        super.inputHiddenPassword = true;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public Hors(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/IKEA.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/IKEA.java
@@ -30,8 +30,6 @@ public class IKEA extends AbsIkanoPartner {
 
     private static final String NAME = "IKEA HANDLA kort";
 
-    private static final String NAME_SHORT = "ikea";
-
     private static final String URL
             = "https://partner.ikanobank.se/web/engines/page.aspx?structid=1420";
 
@@ -40,11 +38,18 @@ public class IKEA extends AbsIkanoPartner {
     public IKEA(Context context) {
         super(context, R.drawable.logo_ikea);
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
+        super.url = URL;
         this.structId = "1420";
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public IKEA(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/IkanoBank.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/IkanoBank.java
@@ -47,8 +47,6 @@ public class IkanoBank extends Bank {
 
     private static final String NAME = "Ikano Bank";
 
-    private static final String NAME_SHORT = "ikanobank";
-
     private static final String URL = "https://secure.ikanobank.se/engines/page.aspx?structid=1895";
 
     private static final int BANKTYPE_ID = IBankTypes.IKANOBANK;
@@ -81,13 +79,20 @@ public class IkanoBank extends Bank {
     public IkanoBank(Context context) {
         super(context, R.drawable.logo_ikanobank);
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
-        super.INPUT_TYPE_PASSWORD = INPUT_TYPE_PASSWORD;
-        super.INPUT_HINT_USERNAME = INPUT_HINT_USERNAME;
+        super.url = URL;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+        super.inputTypePassword = INPUT_TYPE_PASSWORD;
+        super.inputHintUsername = INPUT_HINT_USERNAME;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public IkanoBank(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Jojo.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Jojo.java
@@ -48,8 +48,6 @@ public class Jojo extends Bank {
 
     private static final String NAME = "Jojo Reskassa";
 
-    private static final String NAME_SHORT = "jojo";
-
     private static final String URL = "https://www.skanetrafiken.se";
 
     private static final int BANKTYPE_ID = IBankTypes.JOJO;
@@ -64,12 +62,19 @@ public class Jojo extends Bank {
     public Jojo(Context context) {
         super(context, R.drawable.logo_jojo);
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.INPUT_TITLETEXT_USERNAME = R.string.email;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
+        super.url = URL;
+        super.inputTitletextUsername = R.string.email;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public Jojo(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/McDonalds.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/McDonalds.java
@@ -45,8 +45,6 @@ public class McDonalds extends Bank {
 
     private static final String NAME = "McDonald's Presentkort";
 
-    private static final String NAME_SHORT = "mcdonalds";
-
     private static final String URL = "http://apps.mcdonalds.se/sweden/giftquer.nsf/egift?OpenForm";
 
     private static final int BANKTYPE_ID = Bank.MCDONALDS;
@@ -67,13 +65,20 @@ public class McDonalds extends Bank {
     public McDonalds(Context context) {
         super(context, R.drawable.logo_mcdonalds);
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
-        super.INPUT_HIDDEN_PASSWORD = INPUT_HIDDEN_PASSWORD;
-        super.INPUT_TITLETEXT_USERNAME = INPUT_TITLETEXT_USERNAME;
+        super.url = URL;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+        super.inputHiddenPassword = INPUT_HIDDEN_PASSWORD;
+        super.inputTitletextUsername = INPUT_TITLETEXT_USERNAME;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public McDonalds(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Meniga.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Meniga.java
@@ -32,8 +32,6 @@ public class Meniga extends Bank {
 
     private static final String NAME = "Meniga";
 
-    private static final String NAME_SHORT = "meniga";
-
     private static final String URL = "https://www.meniga.is/";
 
     private static final int BANKTYPE_ID = IBankTypes.MENIGA;
@@ -53,13 +51,20 @@ public class Meniga extends Bank {
     public Meniga(Context context) {
         super(context, R.drawable.logo_meniga);
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
-        super.INPUT_HINT_USERNAME = INPUT_HINT_USERNAME;
+        super.url = URL;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+        super.inputHintUsername = INPUT_HINT_USERNAME;
         super.setCurrency("ISK");
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public Meniga(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/MinPension.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/MinPension.java
@@ -48,13 +48,19 @@ public class MinPension extends Bank {
 
     public MinPension(Context context) {
         super(context, R.drawable.logo_minpension);
-        TAG = "MinPension";
-        NAME = "Min Pension.se";
-        NAME_SHORT = "minpension";
-        BANKTYPE_ID = IBankTypes.MINPENSION;
-        INPUT_TYPE_USERNAME = InputType.TYPE_CLASS_PHONE;
-        INPUT_TYPE_PASSWORD = InputType.TYPE_CLASS_PHONE | InputType.TYPE_TEXT_VARIATION_PASSWORD;
-        INPUT_HINT_USERNAME = res.getText(R.string.pno).toString();
+        inputTypeUsername = InputType.TYPE_CLASS_PHONE;
+        inputTypePassword = InputType.TYPE_CLASS_PHONE | InputType.TYPE_TEXT_VARIATION_PASSWORD;
+        inputHintUsername = res.getText(R.string.pno).toString();
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return IBankTypes.MINPENSION;
+    }
+
+    @Override
+    public String getName() {
+        return "Min Pension.se";
     }
 
     public MinPension(String username, String password, Context context)
@@ -128,8 +134,8 @@ public class MinPension extends Bank {
         super.updateComplete();
     }
 
-    private Account updateAccount(String URL, String selector, String name) throws IOException {
-        String response = urlopen.open(URL);
+    private Account updateAccount(String url, String selector, String name) throws IOException {
+        String response = urlopen.open(url);
         Document dResponse = Jsoup.parse(response);
         List<Transaction> transactions = new ArrayList<>();
         String institute = "";

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Nordnet.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Nordnet.java
@@ -48,8 +48,6 @@ public class Nordnet extends Bank {
 
     private static final String NAME = "Nordnet";
 
-    private static final String NAME_SHORT = "nordnet";
-
     private static final String URL = "https://www.nordnet.se/mux/login/startSE.html";
 
     private static final int BANKTYPE_ID = IBankTypes.NORDNET;
@@ -66,10 +64,17 @@ public class Nordnet extends Bank {
     public Nordnet(Context context) {
         super(context, R.drawable.logo_nordnet);
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
+        super.url = URL;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public Nordnet(String username, String password, Context context) throws BankException,
@@ -128,32 +133,32 @@ public class Nordnet extends Bank {
             throw new LoginException(res.getText(R.string.invalid_username_password).toString());
         }
         urlopen = login();
-        Matcher matcher = reAccounts.matcher(response);
-        Matcher matcher_b = reBalance.matcher(response);
-        while (matcher.find()) {
+        Matcher accountMatcher = reAccounts.matcher(response);
+        Matcher balanceMatcher = reBalance.matcher(response);
+        while (accountMatcher.find()) {
             /*
              * Capture groups:
              * GROUP                EXAMPLE DATA
              * 1: Account name and number      Investeringssparkonto 1234567   | Sparkonto 1234 567890 1
              *
              */
-            if (matcher_b.find()) {
+            if (balanceMatcher.find()) {
                 /*
                 * Capture groups:
                 * GROUP                EXAMPLE DATA
                 * 1: Account balance     62 356 | 0
                 *
                 */
-                Account account = new Account(Html.fromHtml(matcher.group(1)).toString().trim(),
-                        Helpers.parseBalance(matcher_b.group(1)),
-                        Html.fromHtml(matcher.group(1)).toString().trim().replaceAll(" ", ""));
+                Account account = new Account(Html.fromHtml(accountMatcher.group(1)).toString().trim(),
+                        Helpers.parseBalance(balanceMatcher.group(1)),
+                        Html.fromHtml(accountMatcher.group(1)).toString().trim().replaceAll(" ", ""));
 
                 // Saving accounts contain white space characters in the account number
-                if (!matcher.group(1).trim().contains(" ")) {
+                if (!accountMatcher.group(1).trim().contains(" ")) {
                     account.setType(Account.FUNDS);
                 }
                 accounts.add(account);
-                balance = balance.add(Helpers.parseBalance(matcher_b.group(1)));
+                balance = balance.add(Helpers.parseBalance(balanceMatcher.group(1)));
             }
         }
 

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/OKQ8.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/OKQ8.java
@@ -47,8 +47,6 @@ public class OKQ8 extends Bank {
 
     private static final String NAME = "OKQ8 VISA";
 
-    private static final String NAME_SHORT = "okq8";
-
     private static final String URL
             = "https://nettbank.edb.com/Logon/index.jsp?domain=0066&from_page=http://www.okq8.se&to_page=https://nettbank.edb.com/cardpayment/transigo/logon/done/okq8";
 
@@ -76,13 +74,20 @@ public class OKQ8 extends Bank {
     public OKQ8(Context context) {
         super(context, R.drawable.logo_okq8);
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
-        super.INPUT_HINT_USERNAME = INPUT_HINT_USERNAME;
-        super.STATIC_BALANCE = STATIC_BALANCE;
+        super.url = URL;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+        super.inputHintUsername = INPUT_HINT_USERNAME;
+        super.staticBalance = STATIC_BALANCE;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public OKQ8(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Ostgotatrafiken.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Ostgotatrafiken.java
@@ -43,8 +43,6 @@ public class Ostgotatrafiken extends Bank {
 
     private static final String NAME = "Östgötatrafiken";
 
-    private static final String NAME_SHORT = "ogt";
-
     private static final int BANKTYPE_ID = IBankTypes.OSTGOTATRAFIKEN;
 
     private Pattern reViewState = Pattern.compile(
@@ -68,10 +66,16 @@ public class Ostgotatrafiken extends Bank {
 
     public Ostgotatrafiken(Context context) {
         super(context, R.drawable.logo_ogt);
+    }
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public Ostgotatrafiken(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Osuuspankki.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Osuuspankki.java
@@ -45,8 +45,6 @@ public class Osuuspankki extends Bank {
 
     private static final String NAME = "Osuuspankki";
 
-    private static final String NAME_SHORT = "osuuspankki";
-
     private static final String URL = "https://www.op.fi/op?kielikoodi=sv";
 
     private static final int BANKTYPE_ID = IBankTypes.OSUUSPANKKI;
@@ -62,11 +60,17 @@ public class Osuuspankki extends Bank {
 
     public Osuuspankki(Context context) {
         super(context, R.drawable.logo_osuuspankki);
+        super.url = URL;
+    }
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public Osuuspankki(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Payson.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Payson.java
@@ -46,8 +46,6 @@ public class Payson extends Bank {
 
     private static final String NAME = "Payson";
 
-    private static final String NAME_SHORT = "payson";
-
     private static final String URL = "https://www.payson.se/signin/";
 
     private static final int BANKTYPE_ID = IBankTypes.PAYSON;
@@ -66,11 +64,18 @@ public class Payson extends Bank {
     public Payson(Context context) {
         super(context, R.drawable.logo_payson);
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
+        super.url = URL;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public Payson(String username, String password, Context context) throws BankChoiceException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/PlusGirot.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/PlusGirot.java
@@ -45,8 +45,6 @@ public class PlusGirot extends Bank {
 
     private static final String NAME = "PlusGirot";
 
-    private static final String NAME_SHORT = "plusgirot";
-
     private static final String URL = "https://kontoutdrag.plusgirot.se/";
 
     private static final int BANKTYPE_ID = IBankTypes.PLUSGIROT;
@@ -63,11 +61,17 @@ public class PlusGirot extends Bank {
 
     public PlusGirot(Context context) {
         super(context, R.drawable.logo_plusgirot);
+        super.url = URL;
+    }
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public PlusGirot(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/SevenDay.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/SevenDay.java
@@ -45,8 +45,6 @@ public class SevenDay extends Bank {
 
     private static final String NAME = "SevenDay";
 
-    private static final String NAME_SHORT = "sevenday";
-
     private static final String URL = "https://www.sevenday.se/mina-sidor/mina-sidor.htm";
 
     private static final int BANKTYPE_ID = IBankTypes.SEVENDAY;
@@ -67,12 +65,19 @@ public class SevenDay extends Bank {
     public SevenDay(Context context) {
         super(context, R.drawable.logo_sevenday);
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
-        super.INPUT_HINT_USERNAME = INPUT_HINT_USERNAME;
+        super.url = URL;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+        super.inputHintUsername = INPUT_HINT_USERNAME;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public SevenDay(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/SveaDirekt.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/SveaDirekt.java
@@ -32,8 +32,6 @@ public class SveaDirekt extends Bank {
 
     private static final String NAME = "Svea Direkt";
 
-    private static final String NAME_SHORT = "sveadirekt";
-
     private static final String URL = "https://http://www.sveadirekt.com/sv/swe//";
 
     private static final int BANKTYPE_ID = IBankTypes.SVEADIREKT;
@@ -61,13 +59,20 @@ public class SveaDirekt extends Bank {
     public SveaDirekt(Context context) {
         super(context, R.drawable.logo_sveadirekt);
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.URL = URL;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
-        super.INPUT_TYPE_PASSWORD = INPUT_TYPE_PASSWORD;
-        super.INPUT_HINT_USERNAME = INPUT_HINT_USERNAME;
+        super.url = URL;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+        super.inputTypePassword = INPUT_TYPE_PASSWORD;
+        super.inputHintUsername = INPUT_HINT_USERNAME;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public SveaDirekt(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/SvenskaSpel.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/SvenskaSpel.java
@@ -45,8 +45,6 @@ public class SvenskaSpel extends Bank {
 
     private static final String NAME = "Svenska Spel";
 
-    private static final String NAME_SHORT = "svenskaspel";
-
     private static final String URL = "https://api.www.svenskaspel.se/player/sessions";
 
     private static final int BANKTYPE_ID = Bank.SVENSKASPEL;
@@ -62,12 +60,19 @@ public class SvenskaSpel extends Bank {
     public SvenskaSpel(Context context) {
         super(context, R.drawable.logo_svenskaspel);
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
-        super.INPUT_TITLETEXT_USERNAME = INPUT_TITLETEXT_USERNAME;
+        super.url = URL;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+        super.inputTitletextUsername = INPUT_TITLETEXT_USERNAME;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public SvenskaSpel(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/TestBank.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/TestBank.java
@@ -43,8 +43,6 @@ public class TestBank extends Bank {
 
     private static final String NAME = "Testbank";
 
-    private static final String NAME_SHORT = "testbank";
-
     private static final String URL = "http://www.nullbyte.eu/";
 
     private static final int BANKTYPE_ID = IBankTypes.TESTBANK;
@@ -70,13 +68,20 @@ public class TestBank extends Bank {
     public TestBank(Context context) {
         super(context, R.drawable.logo_bankdroid);
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
-        super.INPUT_TYPE_PASSWORD = INPUT_TYPE_PASSWORD;
-        super.INPUT_HINT_USERNAME = INPUT_HINT_USERNAME;
+        super.url = URL;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+        super.inputTypePassword = INPUT_TYPE_PASSWORD;
+        super.inputHintUsername = INPUT_HINT_USERNAME;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public TestBank(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/TicketRikskortet.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/TicketRikskortet.java
@@ -44,8 +44,6 @@ public class TicketRikskortet extends Bank {
 
     private static final String NAME = "Ticket Rikskortet";
 
-    private static final String NAME_SHORT = "rikskortet";
-
     private static final String URL = "https://www.edenred.se/rikskuponger/mina-sidor/logga-in/";
 
     private static final String URL_OVERVIEW = "https://www.edenred.se/rikskuponger/mina-sidor/employee/start/";
@@ -71,10 +69,17 @@ public class TicketRikskortet extends Bank {
     public TicketRikskortet(Context context) {
         super(context, R.drawable.logo_rikskortet);
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
+        super.url = URL;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public TicketRikskortet(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Vasttrafik.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Vasttrafik.java
@@ -44,8 +44,6 @@ public class Vasttrafik extends Bank {
 
     private static final String NAME = "Västtrafik";
 
-    private static final String NAME_SHORT = "vasttrafik";
-
     private static final String URL = "https://www.vasttrafik.se/mina-sidor/";
 
     private static final int BANKTYPE_ID = IBankTypes.VASTTRAFIK;
@@ -64,11 +62,17 @@ public class Vasttrafik extends Bank {
 
     public Vasttrafik(Context context) {
         super(context, R.drawable.logo_vasttrafik);
+        super.url = URL;
+    }
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public Vasttrafik(String username, String password, Context context) throws BankException,
@@ -127,11 +131,11 @@ public class Vasttrafik extends Bank {
         }
         urlopen = login();
         response = urlopen.open("https://www.vasttrafik.se/mina-sidor-inloggad/mina-kort/");
-        Matcher matcher;
-        Matcher matcher_b;
+        Matcher accountMatcher;
+        Matcher balanceMatcher;
 
-        matcher = reAccounts.matcher(response);
-        while (matcher.find()) {
+        accountMatcher = reAccounts.matcher(response);
+        while (accountMatcher.find()) {
             /*
              * Capture groups:
              * GROUP                EXAMPLE DATA
@@ -139,12 +143,12 @@ public class Vasttrafik extends Bank {
              * 2: Balance information
              */
 
-            if ("".equals(matcher.group(1))) {
+            if ("".equals(accountMatcher.group(1))) {
                 continue;
             }
 
-            matcher_b = reBalance.matcher(matcher.group(2));
-            if (matcher_b.find()) {
+            balanceMatcher = reBalance.matcher(accountMatcher.group(2));
+            if (balanceMatcher.find()) {
                 /*
                  * Capture groups:
                  * GROUP                EXAMPLE DATA
@@ -152,11 +156,11 @@ public class Vasttrafik extends Bank {
                  * 2: Amount            592,80 kr
                  */
 
-                String balanceString = matcher_b.group(2).replaceAll("\\<a[^>]*>", "")
+                String balanceString = balanceMatcher.group(2).replaceAll("\\<a[^>]*>", "")
                         .replaceAll("\\<[^>]*>", "").trim();
 
-                accounts.add(new Account(Html.fromHtml(matcher.group(1)).toString().trim(),
-                        Helpers.parseBalance(balanceString), matcher.group(1)));
+                accounts.add(new Account(Html.fromHtml(accountMatcher.group(1)).toString().trim(),
+                        Helpers.parseBalance(balanceString), accountMatcher.group(1)));
                 balance = balance.add(Helpers.parseBalance(balanceString));
             }
         }

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Zidisha.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/Zidisha.java
@@ -44,8 +44,6 @@ public class Zidisha extends Bank {
 
     private static final String NAME = "Zidisha";
 
-    private static final String NAME_SHORT = "zidisha";
-
     private static final String URL = "https://www.zidisha.org/";
 
     private static final int BANKTYPE_ID = IBankTypes.ZIDISHA;
@@ -70,15 +68,22 @@ public class Zidisha extends Bank {
     public Zidisha(Context context) {
         super(context, R.drawable.logo_zidisha);
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
-        super.INPUT_TYPE_PASSWORD = INPUT_TYPE_PASSWORD;
-        super.INPUT_HINT_USERNAME = INPUT_HINT_USERNAME;
-        super.STATIC_BALANCE = STATIC_BALANCE;
+        super.url = URL;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+        super.inputTypePassword = INPUT_TYPE_PASSWORD;
+        super.inputHintUsername = INPUT_HINT_USERNAME;
+        super.staticBalance = STATIC_BALANCE;
         super.currency = "USD";
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public Zidisha(String username, String password, Context context) throws BankException,
@@ -99,14 +104,14 @@ public class Zidisha extends Bank {
             throw new BankException(
                     res.getText(R.string.unable_to_find).toString() + " user_guess.");
         }
-        String user_guess = mUserGuess.group(1);
+        String userGuess = mUserGuess.group(1);
 
         List<NameValuePair> postData = new ArrayList<NameValuePair>();
         postData.add(new BasicNameValuePair("username", getUsername()));
         postData.add(new BasicNameValuePair("password", getPassword()));
         postData.add(new BasicNameValuePair("textpassword", getUsername()));
         postData.add(new BasicNameValuePair("userlogin", ""));
-        postData.add(new BasicNameValuePair("user_guess", user_guess));
+        postData.add(new BasicNameValuePair("user_guess", userGuess));
         return new LoginPackage(urlopen, postData, response, "https://www.zidisha.org/process.php");
     }
 

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/americanexpress/AmericanExpress.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/americanexpress/AmericanExpress.java
@@ -52,11 +52,7 @@ import eu.nullbyte.android.urllib.Urllib;
 
 public class AmericanExpress extends Bank {
 
-    private static final String TAG = "AmericanExpress";
-
     private static final String NAME = "American Express";
-
-    private static final String NAME_SHORT = "americanexpress";
 
     private static final int BANKTYPE_ID = IBankTypes.AMERICANEXPRESS;
 
@@ -67,11 +63,17 @@ public class AmericanExpress extends Bank {
 
     public AmericanExpress(Context context) {
         super(context, R.drawable.logo_americanexpress);
-        super.TAG = TAG;
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.WEB_VIEW_ENABLED = false;
+        super.webViewEnabled = false;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public AmericanExpress(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/avanza/Avanza.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/avanza/Avanza.java
@@ -57,11 +57,17 @@ public class Avanza extends Bank {
 
     protected Avanza(Context context, @DrawableRes int logoResource) {
         super(context, logoResource);
-        TAG = "Avanza";
-        NAME = "Avanza";
-        NAME_SHORT = "avanza";
-        URL = "https://iphone.avanza.se";
-        BANKTYPE_ID = IBankTypes.AVANZA;
+        url = "https://iphone.avanza.se";
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return IBankTypes.AVANZA;
+    }
+
+    @Override
+    public String getName() {
+        return "Avanza";
     }
 
     public Avanza(Context context) {
@@ -72,12 +78,12 @@ public class Avanza extends Bank {
     protected LoginPackage preLogin() throws BankException, IOException {
         urlopen = new Urllib(context,
                 CertificateReader.getCertificates(context, R.raw.cert_avanza));
-        urlopen.addHeader("Referer", URL + "/start");
+        urlopen.addHeader("Referer", url + "/start");
         List<NameValuePair> postData = new ArrayList<NameValuePair>();
         postData.add(new BasicNameValuePair("j_username", getUsername()));
         postData.add(new BasicNameValuePair("j_password", getPassword()));
-        postData.add(new BasicNameValuePair("url", URL + "/start"));
-        String response = urlopen.open(URL + "/ab/handlelogin", postData);
+        postData.add(new BasicNameValuePair("url", url + "/start"));
+        String response = urlopen.open(url + "/ab/handlelogin", postData);
         String homeUrl = "";
         try {
             JSONObject jsonResponse = new JSONObject(response);
@@ -86,7 +92,7 @@ public class Avanza extends Bank {
             throw new BankException(
                     res.getText(R.string.unable_to_find).toString() + " login link.", e);
         }
-        LoginPackage lp = new LoginPackage(urlopen, postData, "", URL + homeUrl);
+        LoginPackage lp = new LoginPackage(urlopen, postData, "", url + homeUrl);
         lp.setIsLoggedIn(true);
         return lp;
     }

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/bitcoin/Bitcoin.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/bitcoin/Bitcoin.java
@@ -40,8 +40,6 @@ public class Bitcoin extends Bank {
 
     private static final String NAME = "Bitcoin";
 
-    private static final String NAME_SHORT = "bitcoin";
-
     private static final String URL = "http://blockchain.info";
 
     private static final int BANKTYPE_ID = IBankTypes.BITCOIN;
@@ -59,14 +57,21 @@ public class Bitcoin extends Bank {
     public Bitcoin(Context context) {
         super(context, R.drawable.logo_bitcoin);
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.STATIC_BALANCE = STATIC_BALANCE;
+        super.url = URL;
+        super.staticBalance = STATIC_BALANCE;
         super.currency = "BTC";
-        super.INPUT_HIDDEN_PASSWORD = INPUT_HIDDEN_PASSWORD;
-        super.INPUT_TITLETEXT_USERNAME = INPUT_TITLETEXT_USERNAME;
+        super.inputHiddenPassword = INPUT_HIDDEN_PASSWORD;
+        super.inputTitletextUsername = INPUT_TITLETEXT_USERNAME;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public Bitcoin(String username, String password, Context context)

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/coop/Coop.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/coop/Coop.java
@@ -57,8 +57,6 @@ public class Coop extends Bank {
 
     private static final String NAME = "Coop";
 
-    private static final String NAME_SHORT = "coop";
-
     private static final String URL = "https://www.coop.se/mina-sidor/oversikt/";
 
     private static final int BANKTYPE_ID = IBankTypes.COOP;
@@ -83,11 +81,18 @@ public class Coop extends Bank {
     public Coop(Context context) {
         super(context, R.drawable.logo_coop);
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.STATIC_BALANCE = true;
+        super.url = URL;
+        super.staticBalance = true;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public Coop(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/ica/ICA.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/ica/ICA.java
@@ -66,17 +66,23 @@ public class ICA extends Bank {
 
     public ICA(Context context) {
         super(context, R.drawable.logo_ica);
-        TAG = "ICA";
-        NAME = "ICA";
-        NAME_SHORT = "ica";
-        URL = "http://mobil.ica.se/";
-        BANKTYPE_ID = IBankTypes.ICA;
-        INPUT_TYPE_USERNAME = InputType.TYPE_CLASS_PHONE;
-        INPUT_TYPE_PASSWORD = InputType.TYPE_CLASS_PHONE;
-        INPUT_HINT_USERNAME = "ÅÅMMDDXXXX";
+        url = "http://mobil.ica.se/";
+        inputTypeUsername = InputType.TYPE_CLASS_PHONE;
+        inputTypePassword = InputType.TYPE_CLASS_PHONE;
+        inputHintUsername = "ÅÅMMDDXXXX";
         mHeaders.put(AUTHENTICATION_TICKET_HEADER, null);
         mHeaders.put(SESSION_TICKET_HEADER, null);
         mHeaders.put(LOGOUT_KEY_HEADER, null);
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return IBankTypes.ICA;
+    }
+
+    @Override
+    public String getName() {
+        return "ICA";
     }
 
     public ICA(String username, String password, Context context)

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/lansforsakringar/Lansforsakringar.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/lansforsakringar/Lansforsakringar.java
@@ -64,8 +64,6 @@ public class Lansforsakringar extends Bank {
 
     private static final String NAME = "Länsförsäkringar";
 
-    private static final String NAME_SHORT = "lansforsakringar";
-
     private static final int BANKTYPE_ID = IBankTypes.LANSFORSAKRINGAR;
 
     private static final int INPUT_TYPE_USERNAME = InputType.TYPE_CLASS_PHONE;
@@ -83,15 +81,22 @@ public class Lansforsakringar extends Bank {
     public Lansforsakringar(Context context) {
         super(context, R.drawable.logo_lansforsakringar);
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
-        super.INPUT_TYPE_PASSWORD = INPUT_TYPE_PASSWORD;
-        super.INPUT_HINT_USERNAME = INPUT_HINT_USERNAME;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+        super.inputTypePassword = INPUT_TYPE_PASSWORD;
+        super.inputHintUsername = INPUT_HINT_USERNAME;
         mObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         mObjectMapper.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false);
         mObjectMapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public Urllib login() throws LoginException, BankException, IOException {

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/nordea/Nordea.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/nordea/Nordea.java
@@ -46,8 +46,6 @@ public class Nordea extends Bank {
 
     private static final String NAME = "Nordea";
 
-    private static final String NAME_SHORT = "nordea";
-
     private static final String BASE_URL = "https://internetbanken.privat.nordea.se/nsp/";
 
     private static final String LOGIN_URL = BASE_URL + "login";
@@ -210,13 +208,20 @@ public class Nordea extends Bank {
     public Nordea(Context context) {
         super(context, R.drawable.logo_nordea);
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = BASE_URL;
-        super.INPUT_TYPE_USERNAME = INPUT_TYPE_USERNAME;
-        super.INPUT_TYPE_PASSWORD = INPUT_TYPE_PASSWORD;
-        super.INPUT_HINT_USERNAME = INPUT_HINT_USERNAME;
+        super.url = BASE_URL;
+        super.inputTypeUsername = INPUT_TYPE_USERNAME;
+        super.inputTypePassword = INPUT_TYPE_PASSWORD;
+        super.inputHintUsername = INPUT_HINT_USERNAME;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public Nordea(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/rikslunchen/Rikslunchen.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/banking/banks/rikslunchen/Rikslunchen.java
@@ -40,8 +40,6 @@ public class Rikslunchen extends Bank {
 
     private static final String NAME = "Rikslunchen";
 
-    private static final String NAME_SHORT = "rikslunchen";
-
     private static final String URL = "http://www.rikslunchen.se/index.html";
 
     private static final int BANKTYPE_ID = Bank.RIKSLUNCHEN;
@@ -53,13 +51,20 @@ public class Rikslunchen extends Bank {
     public Rikslunchen(Context context) {
         super(context, R.drawable.logo_rikslunchen);
 
-        super.NAME = NAME;
-        super.NAME_SHORT = NAME_SHORT;
-        super.BANKTYPE_ID = BANKTYPE_ID;
-        super.URL = URL;
-        super.INPUT_TYPE_USERNAME = InputType.TYPE_CLASS_PHONE;
-        super.INPUT_TITLETEXT_USERNAME = R.string.card_id;
-        super.INPUT_HIDDEN_PASSWORD = true;
+        super.url = URL;
+        super.inputTypeUsername = InputType.TYPE_CLASS_PHONE;
+        super.inputTitletextUsername = R.string.card_id;
+        super.inputHiddenPassword = true;
+    }
+
+    @Override
+    public int getBanktypeId() {
+        return BANKTYPE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public Rikslunchen(String username, String password, Context context) throws BankException,

--- a/bankdroid-legacy/src/main/java/eu/nullbyte/android/urllib/Urllib.java
+++ b/bankdroid-legacy/src/main/java/eu/nullbyte/android/urllib/Urllib.java
@@ -88,9 +88,9 @@ import timber.log.Timber;
 
 public class Urllib {
 
-    private static int MAX_RETRIES = 5;
+    private final static int MAX_RETRIES = 5;
 
-    public static String DEFAULT_USER_AGENT
+    public final static String DEFAULT_USER_AGENT
             = "Mozilla/5.0 (Linux; U; Android 2.1; en-us; Nexus One Build/ERD62) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17";
 
     private String userAgent = null;

--- a/config/quality/lint/lint.xml
+++ b/config/quality/lint/lint.xml
@@ -30,7 +30,6 @@
     <issue id="NewerVersionAvailable" severity="ignore" />
     <issue id="NotSibling" severity="ignore" />
     <issue id="ObsoleteLayoutParam" severity="ignore" />
-    <issue id="OldTargetApi" severity="ignore" />
     <issue id="Orientation" severity="ignore" />
     <issue id="Overdraw" severity="ignore" />
     <issue id="ParcelClassLoader" severity="ignore" />

--- a/config/quality/pmd/pmd-ruleset.xml
+++ b/config/quality/pmd/pmd-ruleset.xml
@@ -113,7 +113,6 @@
         <exclude name="SimplifyBooleanReturns" />
         <exclude name="SimplifyStartsWith" />
         <exclude name="StdCyclomaticComplexity" />
-        <exclude name="SuspiciousConstantFieldName" />
         <exclude name="SwitchDensity" />
         <exclude name="SwitchStmtsShouldHaveDefault" />
         <exclude name="TooFewBranchesForASwitchStatement" />
@@ -139,6 +138,5 @@
         <exclude name="UselessOverridingMethod" />
         <exclude name="UselessParentheses" />
         <exclude name="UselessQualifiedThis" />
-        <exclude name="VariableNamingConventions" />
     </rule>
 </ruleset>


### PR DESCRIPTION
Inspired by:
https://github.com/liato/android-bankdroid/pull/667/files/0513e7c0b45b748b342ebb61026ee18f5cfc5322#r86446572

Naming conventions violations are better found by tooling.

Non-final fields with NAMING_INDICATING_FINALITY have been turned into
final fields when possible.

In Bank.java, refactored the API a bit so that bank names can be
constant.

Unit tests pass, and I've tested adding Länsförsäkringar as a bank and checking
my accounts, and that still works.