### PR TITLE
Blame Urllib problems on the callers

### DIFF
--- a/bankdroid-legacy/src/main/java/com/liato/bankdroid/utils/ExceptionUtils.java
+++ b/bankdroid-legacy/src/main/java/com/liato/bankdroid/utils/ExceptionUtils.java
@@ -1,6 +1,8 @@
 package com.liato.bankdroid.utils;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
@@ -11,41 +13,109 @@ public class ExceptionUtils {
     private static final String PREFIX = "com.liato.bankdroid.";
 
     /**
-     * Take an exception thrown and make it look like it came from Bankdroid.
+     * Modify an Exception to make it look like it was ultimately caused by Bankdroid.
      * <p/>
-     * Specifically, if Urllib.java, called by Bankdroid code, throws an exception,
-     * rewrite the exception so that it appears as if it was thrown from the
-     * Bankdroid method calling Urllib, but caused by the original Exception.
+     * The purpose is to make Crashlytics report Urllib exceptions as coming from whatever
+     * bank Urllib is trying to access.
+     * <p/>
+     * For example, this exception:
+     * <pre>
+     * java.lang.Exception: This is a test Exception
+     *     at not.bankdroid.at.all.ExceptionFactory.getException(ExceptionFactory.java:20)
+     *     at com.liato.bankdroid.utils.ExceptionUtilsTest.testBlameBankdroid(ExceptionUtilsTest.java:16)
+     *     at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+     *     at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+     *     at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+     *     at java.lang.reflect.Method.invoke(Method.java:497)
+     *     at ...
+     * </pre>
+     *
+     * Would be turned into this exception:
+     * <pre>
+     * java.lang.Exception: This is a test Exception
+     *     at not.bankdroid.at.all.ExceptionFactory.getException(ExceptionFactory.java:20)
+     *     at com.liato.bankdroid.utils.ExceptionUtilsTest.testBlameBankdroid(ExceptionUtilsTest.java:16)
+     *     at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+     *     at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+     *     at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+     *     at java.lang.reflect.Method.invoke(Method.java:497)
+     *     at ...
+     * Caused by: java.lang.Exception: This is a test Exception
+     *     at com.liato.bankdroid.utils.ExceptionUtilsTest.testBlameBankdroid(ExceptionUtilsTest.java:16)
+     *     at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+     *     at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+     *     at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+     *     at java.lang.reflect.Method.invoke(Method.java:497)
+     *     at ...
+     *     ... 37 more
+     * </pre>
      */
-    public static <T extends Throwable> T bankdroidifyException(T exception) {
+    public static void blameBankdroid(Throwable exception) {
+        Throwable ultimateCause = getUltimateCause(exception);
+        if (ultimateCause == null) {
+            // Unable to find ultimate cause, never mind
+            return;
+        }
+
         StackTraceElement[] bankdroidifiedStacktrace =
-                bankdroidifyStacktrace(exception.getStackTrace());
-        if (bankdroidifiedStacktrace.length == exception.getStackTrace().length) {
-            // Unable to bankdroidify stacktrace, never mind
-            return exception;
+                bankdroidifyStacktrace(ultimateCause.getStackTrace());
+        if (bankdroidifiedStacktrace.length == 0) {
+            // No Bankdroid stack frames found, never mind
+            return;
+        }
+        if (bankdroidifiedStacktrace.length == ultimateCause.getStackTrace().length) {
+            // Bankdroid already to blame, never mind
+            return;
         }
 
-        T returnMe = createWrapperException(exception);
-        if (returnMe == null) {
+        Throwable fakeCause = cloneException(ultimateCause);
+        if (fakeCause == null) {
             Timber.w(new RuntimeException(
-                    "Unable to bankdroidify exception of class: " + exception.getClass()));
-            return exception;
+                    "Unable to bankdroidify exception of class: " + ultimateCause.getClass()));
+            return;
         }
 
-        returnMe.initCause(exception);
+        // Put the bankdroidified stack trace before the fakeCause's actual stack trace
+        fakeCause.setStackTrace(concatArrays(bankdroidifiedStacktrace, fakeCause.getStackTrace()));
 
-        returnMe.setStackTrace(bankdroidifiedStacktrace);
+        ultimateCause.initCause(fakeCause);
+    }
 
+    @VisibleForTesting
+    static StackTraceElement[] concatArrays(StackTraceElement[] a, StackTraceElement[] b) {
+        StackTraceElement[] returnMe = new StackTraceElement[a.length + b.length];
+        System.arraycopy(a, 0, returnMe, 0, a.length);
+        System.arraycopy(b, 0, returnMe, a.length, b.length);
         return returnMe;
     }
 
+    @VisibleForTesting
     @Nullable
-    private static <T extends Throwable> T createWrapperException(T wrapMe) {
+    static Throwable getUltimateCause(Throwable t) {
+        int laps = 0;
+        Throwable ultimateCause = t;
+        while (ultimateCause.getCause() != null) {
+            ultimateCause = ultimateCause.getCause();
+            if (laps++ > 10) {
+                return null;
+            }
+        }
+        return ultimateCause;
+    }
+
+    /**
+     * Clone message and stacktrace but not the cause.
+     */
+    @Nullable
+    @VisibleForTesting
+    static <T extends Throwable> T cloneException(T wrapMe) {
         Class<?> newClass = wrapMe.getClass();
         while (newClass != null) {
             try {
-                return (T) newClass.getConstructor(String.class)
-                        .newInstance(wrapMe.getMessage());
+                T returnMe =
+                        (T) newClass.getConstructor(String.class).newInstance(wrapMe.getMessage());
+                returnMe.setStackTrace(wrapMe.getStackTrace());
+                return returnMe;
             } catch (InvocationTargetException e) {
                 newClass = newClass.getSuperclass();
             } catch (NoSuchMethodException e) {
@@ -63,9 +133,12 @@ public class ExceptionUtils {
     /**
      * Remove all initial non-Bankdroid frames from a stack.
      *
-     * @return A copy of rawStack but with the initial non-Bankdroid frames removed
+     * @return A copy of rawStack but with the initial non-Bankdroid frames removed, or null
+     * if no sensible answer can be given.
      */
-    private static StackTraceElement[] bankdroidifyStacktrace(final StackTraceElement[] rawStack) {
+    @VisibleForTesting
+    @NonNull
+    static StackTraceElement[] bankdroidifyStacktrace(final StackTraceElement[] rawStack) {
         for (int i = 0; i < rawStack.length; i++) {
             StackTraceElement stackTraceElement = rawStack[i];
             if (stackTraceElement.getClassName().startsWith(PREFIX)) {
@@ -74,6 +147,6 @@ public class ExceptionUtils {
         }
 
         // No Bankdroid stack frames found, never mind
-        return rawStack;
+        return new StackTraceElement[0];
     }
 }

--- a/bankdroid-legacy/src/main/java/eu/nullbyte/android/urllib/Urllib.java
+++ b/bankdroid-legacy/src/main/java/eu/nullbyte/android/urllib/Urllib.java
@@ -149,7 +149,8 @@ public class Urllib {
         try {
             return this.open(url, new ArrayList<NameValuePair>());
         } catch (IOException e) {
-            throw ExceptionUtils.bankdroidifyException(e);
+            ExceptionUtils.blameBankdroid(e);
+            throw e;
         }
     }
 
@@ -162,7 +163,8 @@ public class Urllib {
         try {
             return open(url, postData, false);
         } catch (IOException e) {
-            throw ExceptionUtils.bankdroidifyException(e);
+            ExceptionUtils.blameBankdroid(e);
+            throw e;
         }
     }
 
@@ -182,7 +184,8 @@ public class Urllib {
         try {
             return openAsHttpResponse(url, entity, forcePost);
         } catch (IOException e) {
-            throw ExceptionUtils.bankdroidifyException(e);
+            ExceptionUtils.blameBankdroid(e);
+            throw e;
         }
     }
 
@@ -200,7 +203,8 @@ public class Urllib {
                 return openAsHttpResponse(url, entity, HttpMethod.POST);
             }
         } catch (IOException e) {
-            throw ExceptionUtils.bankdroidifyException(e);
+            ExceptionUtils.blameBankdroid(e);
+            throw e;
         }
     }
 
@@ -293,7 +297,8 @@ public class Urllib {
             return openStream(url, postData != null ? new StringEntity(postData, this.charset) : null,
                     forcePost);
         } catch (IOException e) {
-            throw ExceptionUtils.bankdroidifyException(e);
+            ExceptionUtils.blameBankdroid(e);
+            throw e;
         }
     }
 

--- a/bankdroid-legacy/src/test/java/com/liato/bankdroid/utils/ExceptionUtilsTest.java
+++ b/bankdroid-legacy/src/test/java/com/liato/bankdroid/utils/ExceptionUtilsTest.java
@@ -3,17 +3,130 @@ package com.liato.bankdroid.utils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.ConnectException;
 
 import eu.nullbyte.android.urllib.Urllib;
-import not.bankdroid.at.all.ExceptionThrower;
+import not.bankdroid.at.all.ExceptionFactory;
 
-@SuppressWarnings("CallToPrintStackTrace")
 public class ExceptionUtilsTest {
     @Test
-    @SuppressWarnings({"PMD.AvoidPrintStackTrace", "PMD.AvoidCatchingNPE", "PMD.SystemPrintln"})
-    public void testBankdroidifyException() throws Exception {
-        Exception raw = null;
+    public void testBlameBankdroid() {
+        Exception e = ExceptionFactory.getException();
+        String before = toStringWithStacktrace(e);
+        ExceptionUtils.blameBankdroid(e);
+        String after = toStringWithStacktrace(e);
+        String description =
+                String.format("\n---- Before ----\n%s---- After ----\n%s----", before, after);
+
+        String[] afterLines = after.split("\n");
+        int lastCausedByIndex = 0;
+        for (int i = 0; i < afterLines.length; i++) {
+            if (afterLines[i].startsWith("Caused by: ")) {
+                lastCausedByIndex = i;
+            }
+        }
+
+        Assert.assertNotEquals(description, 0, lastCausedByIndex);
+        Assert.assertTrue(description,
+                afterLines[lastCausedByIndex + 1].startsWith("\tat com.liato.bankdroid."));
+    }
+
+    /**
+     * Like {@link #testBlameBankdroid()} but with an Exception with a cause.
+     */
+    @Test
+    public void testBlameBankdroidWithCause() {
+        Exception e = ExceptionFactory.getExceptionWithCause();
+        String before = toStringWithStacktrace(e);
+        ExceptionUtils.blameBankdroid(e);
+        String after = toStringWithStacktrace(e);
+        String description =
+                String.format("\n---- Before ----\n%s---- After ----\n%s----", before, after);
+
+        String[] afterLines = after.split("\n");
+        int firstCausedByIndex = 0;
+        for (int i = 0; i < afterLines.length; i++) {
+            if (afterLines[i].startsWith("Caused by: ")) {
+                firstCausedByIndex = i;
+                break;
+            }
+        }
+        Assert.assertNotEquals(description, 0, firstCausedByIndex);
+        Assert.assertTrue(description,
+                afterLines[firstCausedByIndex + 1].startsWith("\tat not.bankdroid.at.all."));
+
+        int lastCausedByIndex = 0;
+        for (int i = 0; i < afterLines.length; i++) {
+            if (afterLines[i].startsWith("Caused by: ")) {
+                lastCausedByIndex = i;
+            }
+        }
+        Assert.assertNotEquals(description, 0, lastCausedByIndex);
+        Assert.assertTrue(description,
+                afterLines[lastCausedByIndex + 1].startsWith("\tat com.liato.bankdroid."));
+    }
+
+    @Test
+    public void testBlameBankdroidAlreadyToBlame() {
+        // Creating it here we're already inside of Bankdroid code, blaming bankdroid should be a
+        // no-op
+        Exception e = new Exception();
+
+        String before = toStringWithStacktrace(e);
+
+        ExceptionUtils.blameBankdroid(e);
+        String after = toStringWithStacktrace(e);
+
+        Assert.assertEquals(before, after);
+    }
+
+    private String toStringWithStacktrace(Exception e) {
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter printWriter = new PrintWriter(stringWriter);
+        e.printStackTrace(printWriter);
+        printWriter.close();
+        return stringWriter.toString();
+    }
+
+    @Test
+    public void testBankdroidifyStacktrace() {
+        StackTraceElement[] bankdroidified = new StackTraceElement[] {
+                new StackTraceElement("not.bankdroid.SomeClass", "someMethod", "SomeClass.java", 42),
+                new StackTraceElement("com.liato.bankdroid.SomeOtherClass", "someOtherMethod", "SomeOtherClass.java", 43),
+        };
+        bankdroidified = ExceptionUtils.bankdroidifyStacktrace(bankdroidified);
+
+        StackTraceElement[] expected = new StackTraceElement[] {
+                new StackTraceElement("com.liato.bankdroid.SomeOtherClass", "someOtherMethod", "SomeOtherClass.java", 43),
+        };
+
+        Assert.assertArrayEquals(expected, bankdroidified);
+
+        // Test re-bankdroidification
+        Assert.assertArrayEquals(expected, ExceptionUtils.bankdroidifyStacktrace(bankdroidified));
+    }
+
+    @Test
+    public void testCloneExceptionWonky() {
+        ExceptionFactory.WonkyException raw = ExceptionFactory.getWonkyException();
+
+        @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
+        ConnectException cloned = ExceptionUtils.cloneException(raw);
+
+        assert cloned != null;
+        Assert.assertEquals(raw.getMessage(), cloned.getMessage());
+        Assert.assertArrayEquals(raw.getStackTrace(), cloned.getStackTrace());
+        Assert.assertEquals(
+                "Cloning an uninstantiable Exception should return an instance of its super class",
+                raw.getClass().getSuperclass(), cloned.getClass());
+    }
+
+    @Test
+    @SuppressWarnings({"PMD.AvoidCatchingNPE"})
+    public void testCloneExceptionNPE() {
+        NullPointerException raw = null;
         try {
             //noinspection ConstantConditions
             new Urllib(null);
@@ -22,66 +135,30 @@ public class ExceptionUtilsTest {
             raw = e;
         }
 
-        // Print stack traces, useful if the tests fail
-        System.err.println("Before:");
-        raw.printStackTrace();
+        @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
+        NullPointerException cloned = ExceptionUtils.cloneException(raw);
 
-        System.err.println();
-        System.err.println("After:");
-        Exception bankdroidified = ExceptionUtils.bankdroidifyException(raw);
-        bankdroidified.printStackTrace();
-
-        Assert.assertFalse("Test setup: Top frame of initial exception shouldn't be in Bankdroid",
-                raw.getStackTrace()[0].getClassName().startsWith("com.liato.bankdroid."));
-
-        Assert.assertTrue("Top frame of bankdroidified exception should be in Bankdroid",
-                bankdroidified.getStackTrace()[0].getClassName().startsWith("com.liato.bankdroid."));
-
-        // Verify that e is the cause of bankdroidified
-        Assert.assertSame(raw, bankdroidified.getCause());
-
-        // Verify that re-bankdroidifying is a no-op
-        Assert.assertSame(bankdroidified, ExceptionUtils.bankdroidifyException(bankdroidified));
+        assert cloned != null;
+        Assert.assertEquals(raw.getMessage(), cloned.getMessage());
+        Assert.assertArrayEquals(raw.getStackTrace(), cloned.getStackTrace());
+        Assert.assertEquals(raw.getClass(), cloned.getClass());
     }
 
-    /**
-     * Test that we can wrap exceptions without (String) constructors.
-     */
+    @Test(timeout = 1000)
+    public void testGetUltimateCauseRecursive() {
+        Exception recursive = new Exception();
+        Exception intermediate = new Exception(recursive);
+        recursive.initCause(intermediate);
+        Assert.assertNull(ExceptionUtils.getUltimateCause(recursive));
+    }
+
     @Test
-    @SuppressWarnings({"PMD.AvoidPrintStackTrace", "PMD.SystemPrintln"})
-    public void testBankdroidifyWonkyException() {
-        ExceptionThrower.WonkyException raw = null;
-        try {
-            ExceptionThrower.throwWonkyException();
-            Assert.fail("Exception expected");
-        } catch (ExceptionThrower.WonkyException e) {
-            raw = e;
-        }
-
-        // Print stack traces, useful if the tests fail
-        System.err.println("Before:");
-        raw.printStackTrace();
-
-        // Since bankdroidify() won't be able to create a WonkyException, it
-        // should fall back to creating something it extends
-        ConnectException bankdroidified = ExceptionUtils.bankdroidifyException(raw);
-
-        System.err.println();
-        System.err.println("After:");
-        bankdroidified.printStackTrace();
-
-        Assert.assertFalse("Test setup: Top frame of initial exception shouldn't be in Bankdroid",
-                raw.getStackTrace()[0].getClassName().startsWith("com.liato.bankdroid."));
-
-        Assert.assertTrue("Top frame of bankdroidified exception should be in Bankdroid",
-                bankdroidified.getStackTrace()[0].getClassName().startsWith("com.liato.bankdroid."));
-
-        Assert.assertEquals(raw.getMessage(), bankdroidified.getMessage());
-
-        // Verify that e is the cause of bankdroidified
-        Assert.assertSame(raw, bankdroidified.getCause());
-
-        // Verify that re-bankdroidifying is a no-op
-        Assert.assertSame(bankdroidified, ExceptionUtils.bankdroidifyException(bankdroidified));
+    public void testConcatArrays() {
+        StackTraceElement s1 = new StackTraceElement("a", "b", "c", 123);
+        StackTraceElement s2 = new StackTraceElement("d", "e", "f", 456);
+        StackTraceElement[] concatenated =
+                ExceptionUtils.concatArrays(
+                        new StackTraceElement[]{s1}, new StackTraceElement[]{s2});
+        Assert.assertArrayEquals(new StackTraceElement[]{ s1, s2 }, concatenated);
     }
 }

--- a/bankdroid-legacy/src/test/java/not/bankdroid/at/all/ExceptionFactory.java
+++ b/bankdroid-legacy/src/test/java/not/bankdroid/at/all/ExceptionFactory.java
@@ -1,0 +1,26 @@
+package not.bankdroid.at.all;
+
+import java.net.ConnectException;
+
+/**
+ * For the test in {@link com.liato.bankdroid.utils.ExceptionUtilsTest}
+ */
+public class ExceptionFactory {
+    public static class WonkyException extends ConnectException {
+        public WonkyException(int wonky) {
+            super("Wonky: " + wonky);
+        }
+    }
+
+    public static WonkyException getWonkyException() {
+        return new WonkyException(5);
+    }
+
+    public static Exception getException() {
+        return new Exception("This is a test Exception");
+    }
+
+    public static Exception getExceptionWithCause() {
+        return new Exception("This Exception has a cause", getException());
+    }
+}

--- a/config/quality/lint/lint.xml
+++ b/config/quality/lint/lint.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
-    <!-- Disable since it has external dependencies that we cannot affect.-->
+    <!-- Disable since it has external dependencies that we cannot affect. -->
     <issue id="GradleDependency" severity="ignore" />
+
+    <!-- Disable since it starts failing for non-code-related reasons. -->
+    <issue id="OldTargetApi" severity="ignore" />
 
     <!-- FIXME: This file should be empty and all violations fixed. Then we will all hug. -->
 

--- a/tools/update-suppressions.sh
+++ b/tools/update-suppressions.sh
@@ -21,8 +21,11 @@ function set_lint_suppressions() {
   cat > ${LINT_XML} << EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
-    <!-- Disable since it has external dependencies that we cannot affect.-->
+    <!-- Disable since it has external dependencies that we cannot affect. -->
     <issue id="GradleDependency" severity="ignore" />
+
+    <!-- Disable since it starts failing for non-code-related reasons. -->
+    <issue id="OldTargetApi" severity="ignore" />
 
     <!-- FIXME: This file should be empty and all violations fixed. Then we will all hug. -->
 


### PR DESCRIPTION
For Crashlytics.

The previous attempt at doing this failed, because it tried to modify
the *first* exception in the chain, but it turns out that it's the
*last* exception in the chain that Crashlytics looks at.

So given an Exception...
"
java.lang.Exception: This is a test Exception
    at not.bankdroid.at.all.ExceptionFactory.getException(ExceptionFactory.java:20)
    at com.liato.bankdroid.utils.ExceptionUtilsTest.testBlameBankdroid(ExceptionUtilsTest.java:16)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:497)
    at ...
"
... we now report to Crashlytics:
"
java.lang.Exception: This is a test Exception
    at not.bankdroid.at.all.ExceptionFactory.getException(ExceptionFactory.java:20)
    at com.liato.bankdroid.utils.ExceptionUtilsTest.testBlameBankdroid(ExceptionUtilsTest.java:16)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:497)
    at ...
Caused by: java.lang.Exception: This is a test Exception
    at com.liato.bankdroid.utils.ExceptionUtilsTest.testBlameBankdroid(ExceptionUtilsTest.java:16)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:497)
    at ...
    ... 37 more
"