### PR TITLE
Re-enable some Unused warnings

### DIFF
--- a/bankdroid-legacy/src/main/res/values-sv/strings.xml
+++ b/bankdroid-legacy/src/main/res/values-sv/strings.xml
@@ -2,15 +2,11 @@
     <string name="username">Användarnamn</string>
     <string name="password">Lösenord</string>
     <string name="card_number">Kortnummer</string>
-    <string name="account_number">Kontonummer</string>
-    <string name="control_code">Kontrollkod</string>
     <string name="email">E-post</string>
     <string name="points">poäng</string>
     <string name="card_id">Kort ID</string>
     <string name="balance">Saldo</string>
     <string name="pno">ÅÅÅÅMMDDNNNN</string>
-
-    <string name="nordnetdirekt_extras_title">Nyckel</string>
 
     <string name="bitcoin_address">Bitcoin-adress</string>
     <string name="invalid_bitcoin_address">Ogiltig bitcoin-adress.</string>
@@ -24,7 +20,6 @@
     <string name="no_accounts_found">Inga konton funna</string>
     <string name="invalid_username">Ogiltigt användarnamn.</string>
     <string name="invalid_card_number">Ogiltigt kortnummer.</string>
-    <string name="bank_closed">Banken är för närvarande stängd.</string>
     <string name="server_error_try_again">Serverfel. Var god försök igen om en stund.</string>
     <string name="update_transactions_error">Kunde ej uppdatera transaktionsdata. Var vänlig försök igen senare.</string>
 </resources>

--- a/bankdroid-legacy/src/main/res/values/strings.xml
+++ b/bankdroid-legacy/src/main/res/values/strings.xml
@@ -5,15 +5,11 @@
     <string name="password">Password</string>
     <string name="extras_field">Extras</string>
     <string name="card_number">Card number</string>
-    <string name="account_number">Account number</string>
-    <string name="control_code">Control code</string>
     <string name="email">E-mail</string>
     <string name="points">points</string>
     <string name="card_id">Card ID</string>
     <string name="balance">Balance</string>
     <string name="pno">YYYYMMDDNNNN</string>
-
-    <string name="nordnetdirekt_extras_title">Key</string>
 
     <string name="bitcoin_address">Bitcoin address</string>
     <string name="invalid_bitcoin_address">Invalid bitcoin address.</string>
@@ -27,7 +23,6 @@
     <string name="no_accounts_found">No accounts found</string>
     <string name="invalid_username">Invalid username.</string>
     <string name="invalid_card_number">Invalid card number.</string>
-    <string name="bank_closed">The bank is currently closed.</string>
     <string name="server_error_try_again">Server error. Please try again later.</string>
     <string name="update_transactions_error">"There was a problem updating the transaction details. Please try again later."</string>
 

--- a/config/quality/lint/lint.xml
+++ b/config/quality/lint/lint.xml
@@ -47,8 +47,6 @@
     <issue id="TrulyRandom" severity="ignore" />
     <issue id="UnknownIdInLayout" severity="ignore" />
     <issue id="UnusedAttribute" severity="ignore" />
-    <issue id="UnusedIds" severity="ignore" />
-    <issue id="UnusedResources" severity="ignore" />
     <issue id="UseCompoundDrawables" severity="ignore" />
     <issue id="UselessParent" severity="ignore" />
     <issue id="WorldReadableFiles" severity="ignore" />

--- a/config/quality/lint/lint.xml
+++ b/config/quality/lint/lint.xml
@@ -20,7 +20,6 @@
     <issue id="GoogleAppIndexingWarning" severity="ignore" />
     <issue id="IconDensities" severity="ignore" />
     <issue id="IconDuplicates" severity="ignore" />
-    <issue id="IconExpectedSize" severity="ignore" />
     <issue id="IconLocation" severity="ignore" />
     <issue id="IconMissingDensityFolder" severity="ignore" />
     <issue id="InefficientWeight" severity="ignore" />


### PR DESCRIPTION
Before Android Studio 2.3.0 having these enabled triggered internal errors in Lint. Those errors have now been fixed and the checks can be re-enabled.